### PR TITLE
Use serde_json::from_slice to deserialize from &[u8]

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -131,7 +131,7 @@ impl<T: Send + serde::de::DeserializeOwned + 'static, S: 'static> Extract<S> for
         FutureObj::new(Box::new(async move { 
             fn mk_err<T>(_: T) -> Response { StatusCode::BAD_REQUEST.into_response() }
             let body = await!(body.to_vec()).map_err(mk_err)?;            
-            let json: T = serde_json::from_reader(&body[..]).map_err(mk_err)?;
+            let json: T = serde_json::from_slice(&body).map_err(mk_err)?;
             Ok(Json(json))
         }))
     }


### PR DESCRIPTION
This makes it clear that there is no streaming going on, since deserializing a stream of bytes without first buffering into Vec\<u8\> is when you would typically see serde_json::from_reader come up.