### PR TITLE
Feature: Default Headers Middleware

### DIFF
--- a/examples/default_headers.rs
+++ b/examples/default_headers.rs
@@ -1,0 +1,10 @@
+#![feature(async_await)]
+
+use tide::middleware::DefaultHeaders;
+
+fn main() {
+    let mut app = tide::App::new(());
+    app.middleware(DefaultHeaders::new().header("X-Version", "1.0.0"));
+    app.at("/").get(async || "Hello, world!");
+    app.serve("127.0.0.1:7878")
+}

--- a/examples/default_headers.rs
+++ b/examples/default_headers.rs
@@ -5,7 +5,11 @@ use tide::middleware::DefaultHeaders;
 fn main() {
     let mut app = tide::App::new(());
 
-    app.middleware(DefaultHeaders::new().header("X-Version", "1.0.0"));
+    app.middleware(
+        DefaultHeaders::new()
+            .header("X-Version", "1.0.0")
+            .header("X-Servier", "Tide"),
+    );
 
     app.at("/").get(async || "Hello, world!");
     app.serve("127.0.0.1:7878")

--- a/examples/default_headers.rs
+++ b/examples/default_headers.rs
@@ -4,7 +4,9 @@ use tide::middleware::DefaultHeaders;
 
 fn main() {
     let mut app = tide::App::new(());
+
     app.middleware(DefaultHeaders::new().header("X-Version", "1.0.0"));
+
     app.at("/").get(async || "Hello, world!");
     app.serve("127.0.0.1:7878")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod body;
 mod endpoint;
 mod extract;
 pub mod head;
-mod middleware;
+pub mod middleware;
 mod request;
 mod response;
 mod router;

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -54,10 +54,7 @@ impl<Data> Middleware<Data> for DefaultHeaders {
     ) -> FutureObj<'static, Response> {
         let headers = resp.headers_mut();
         for (key, value) in self.headers.iter() {
-            // if !resp.headers().contains_key(key) {
-            //     resp.headers_mut().insert(key, value.clone());
-            // }
-            headers.entry(key).unwrap().or_insert(value.clone());
+            headers.entry(key).unwrap().or_insert_with(|| value.clone());
         }
         FutureObj::new(Box::new(async { resp }))
     }

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -28,6 +28,7 @@ impl DefaultHeaders {
     }
 
     #[inline]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_wild_err_arm))]
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         K: IntoHeaderName,
@@ -45,7 +46,7 @@ impl DefaultHeaders {
 
     // #[inline]
     // pub fn headers<K, V>(self, key_values_pairs: Vec<KeyValues>) -> Self {
-    //     for [key, value] in key_values_pairs.iter() {
+    //     for [key, value] in key_values_pairs {
     //         self.header(key, value);
     //     }
     //     self

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -12,8 +12,6 @@ pub struct DefaultHeaders {
     headers: HeaderMap,
 }
 
-// type KeyValues = [&'static str; 2];
-
 impl DefaultHeaders {
     pub fn new() -> DefaultHeaders {
         DefaultHeaders::default()
@@ -30,19 +28,13 @@ impl DefaultHeaders {
             Ok(value) => {
                 self.headers.append(key, value);
             }
-            Err(_) => panic!("Cannot create header key value pair"),
+            Err(_) => {
+                panic!("Cannot create default header. Please check your default header values.")
+            }
         }
 
         self
     }
-
-    // #[inline]
-    // pub fn headers<K, V>(self, key_values_pairs: Vec<KeyValues>) -> Self {
-    //     for [key, value] in key_values_pairs {
-    //         self.header(key, value);
-    //     }
-    //     self
-    // }
 }
 
 impl<Data> Middleware<Data> for DefaultHeaders {

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -7,20 +7,12 @@ use http::{
 
 use crate::{head::Head, Middleware, Response};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct DefaultHeaders {
     headers: HeaderMap,
 }
 
 // type KeyValues = [&'static str; 2];
-
-impl Default for DefaultHeaders {
-    fn default() -> Self {
-        DefaultHeaders {
-            headers: HeaderMap::new(),
-        }
-    }
-}
 
 impl DefaultHeaders {
     pub fn new() -> DefaultHeaders {
@@ -60,10 +52,12 @@ impl<Data> Middleware<Data> for DefaultHeaders {
         head: &Head,
         mut resp: Response,
     ) -> FutureObj<'static, Response> {
+        let headers = resp.headers_mut();
         for (key, value) in self.headers.iter() {
-            if !resp.headers().contains_key(key) {
-                resp.headers_mut().insert(key, value.clone());
-            }
+            // if !resp.headers().contains_key(key) {
+            //     resp.headers_mut().insert(key, value.clone());
+            // }
+            headers.entry(key).unwrap().or_insert(value.clone());
         }
         FutureObj::new(Box::new(async { resp }))
     }

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -24,8 +24,8 @@ impl DefaultHeaders {
         HeaderValue: HttpTryFrom<V>,
     {
         let value = HeaderValue::try_from(value)
-            .map_err(|_| ())
-            .expect("Cannot create default header. Please check your default header values.");
+            .map_err(Into::into)
+            .expect("Cannot create default header");
 
         self.headers.append(key, value);
 

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -18,20 +18,16 @@ impl DefaultHeaders {
     }
 
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_wild_err_arm))]
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         K: IntoHeaderName,
         HeaderValue: HttpTryFrom<V>,
     {
-        match HeaderValue::try_from(value) {
-            Ok(value) => {
-                self.headers.append(key, value);
-            }
-            Err(_) => {
-                panic!("Cannot create default header. Please check your default header values.")
-            }
-        }
+        let value = HeaderValue::try_from(value)
+            .map_err(|_| ())
+            .expect("Cannot create default header. Please check your default header values.");
+
+        self.headers.append(key, value);
 
         self
     }

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -1,0 +1,69 @@
+use futures::future::FutureObj;
+
+use http::{
+    header::{HeaderValue, IntoHeaderName},
+    HeaderMap, HttpTryFrom,
+};
+
+use crate::{head::Head, Middleware, Response};
+
+#[derive(Clone)]
+pub struct DefaultHeaders {
+    headers: HeaderMap,
+}
+
+// type KeyValues = [&'static str; 2];
+
+impl Default for DefaultHeaders {
+    fn default() -> Self {
+        DefaultHeaders {
+            headers: HeaderMap::new(),
+        }
+    }
+}
+
+impl DefaultHeaders {
+    pub fn new() -> DefaultHeaders {
+        DefaultHeaders::default()
+    }
+
+    #[inline]
+    pub fn header<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: IntoHeaderName,
+        HeaderValue: HttpTryFrom<V>,
+    {
+        match HeaderValue::try_from(value) {
+            Ok(value) => {
+                self.headers.append(key, value);
+            }
+            Err(_) => panic!("Cannot create header key value pair"),
+        }
+
+        self
+    }
+
+    // #[inline]
+    // pub fn headers<K, V>(self, key_values_pairs: Vec<KeyValues>) -> Self {
+    //     for [key, value] in key_values_pairs.iter() {
+    //         self.header(key, value);
+    //     }
+    //     self
+    // }
+}
+
+impl<Data> Middleware<Data> for DefaultHeaders {
+    fn response(
+        &self,
+        data: &mut Data,
+        head: &Head,
+        mut resp: Response,
+    ) -> FutureObj<'static, Response> {
+        for (key, value) in self.headers.iter() {
+            if !resp.headers().contains_key(key) {
+                resp.headers_mut().insert(key, value.clone());
+            }
+        }
+        FutureObj::new(Box::new(async { resp }))
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -2,6 +2,10 @@ use futures::future::FutureObj;
 
 use crate::{head::Head, Request, Response, RouteMatch};
 
+mod default_headers;
+
+pub use self::default_headers::DefaultHeaders;
+
 /// Middleware for an app with state of type `Data`
 pub trait Middleware<Data>: Send + Sync {
     /// Asynchronously transform the incoming request, or abort further handling by immediately
@@ -11,7 +15,9 @@ pub trait Middleware<Data>: Send + Sync {
         data: &mut Data,
         req: Request,
         params: &RouteMatch<'_>,
-    ) -> FutureObj<'static, Result<Request, Response>>;
+    ) -> FutureObj<'static, Result<Request, Response>> {
+        FutureObj::new(Box::new(async { Ok(req) }))
+    }
 
     /// Asynchronously transform the outgoing response.
     fn response(
@@ -19,7 +25,9 @@ pub trait Middleware<Data>: Send + Sync {
         data: &mut Data,
         head: &Head,
         resp: Response,
-    ) -> FutureObj<'static, Response>;
+    ) -> FutureObj<'static, Response> {
+        FutureObj::new(Box::new(async { resp }))
+    }
 
     // TODO: provide the following, intended to fire *after* the body has been fully sent
 


### PR DESCRIPTION
PR is to add the ability to create default headers for every request. This is more or less taken from actix-web!

I am also trying to add the method `headers` which lets you specify a Vec of headers, e.g.

```rust
let mut app = tide::App::new(());

app.middleware(
  DefaultHeaders::new()
    .headers(vec!(
      ["X-Version", "1.0.0"],
      ["X-Server", "Tide"]
     ))
);
```

As opposed to:

```rust
let mut app = tide::App::new(());

app.middleware(
  DefaultHeaders::new()
    .header("X-Version", "1.0.0")
    .header("X-Server", "Tide")
);
```
Not sure which one is more clear? Currently the latter is what is implemented. If it's decided that the other way is better, I can work on implementing it.