### PR TITLE
(WIP) Nested routers

### DIFF
--- a/examples/simple_nested_router.rs
+++ b/examples/simple_nested_router.rs
@@ -1,0 +1,37 @@
+// A `Router`-nesting version of the example `named_path`.
+
+#![feature(async_await, futures_api)]
+
+use tide::{
+    head::{Named, NamedComponent},
+    Router,
+};
+
+struct Number(i32);
+
+impl NamedComponent for Number {
+    const NAME: &'static str = "num";
+}
+
+impl std::str::FromStr for Number {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(|num| Number(num))
+    }
+}
+
+async fn add_two(Named(number): Named<Number>) -> String {
+    let Number(num) = number;
+    format!("{} plus two is {}", num, num + 2)
+}
+
+fn build_add_two<Data: Clone + Send + Sync + 'static>(router: &mut Router<Data>) {
+    router.at("{num}").get(add_two);
+}
+
+fn main() {
+    let mut app = tide::App::new(());
+    app.at("add_two").nest(build_add_two);
+    app.serve("127.0.0.1:8000");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,6 @@ pub use crate::{
     middleware::Middleware,
     request::Request,
     response::{IntoResponse, Response},
-    router::Resource,
+    router::{Resource, Router},
     url_table::RouteMatch,
 };

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,18 +2,44 @@ use std::collections::HashMap;
 
 use crate::{
     endpoint::{BoxedEndpoint, Endpoint},
-    url_table::{ResolveResult, RouteMatch, UrlTable},
+    url_table::{RouteMatch, UrlTable},
     Middleware,
 };
 
+pub use crate::url_table::ResourceHandle;
+
+pub(crate) struct EndpointInfo<'a, Data> {
+    pub(crate) endpoint: &'a BoxedEndpoint<Data>,
+    pub(crate) params: RouteMatch<'a>,
+    pub(crate) middleware: Vec<&'a (Middleware<Data> + Send + Sync)>,
+}
+
 /// TODO: Write documentation for `Router`
 pub struct Router<Data> {
-    table: UrlTable<Resource<Data>>,
+    table: UrlTable<Router<Data>>,
     middleware: Vec<Box<dyn Middleware<Data> + Send + Sync>>,
 }
 
+impl<Data> crate::url_table::Router for Router<Data> {
+    type Resource = Resource<Data>;
+
+    fn table(&self) -> &UrlTable<Self> {
+        &self.table
+    }
+
+    fn table_mut(&mut self) -> &mut UrlTable<Self> {
+        &mut self.table
+    }
+}
+
+impl<Data> Default for Router<Data> {
+    fn default() -> Router<Data> {
+        Self::new()
+    }
+}
+
 impl<Data> Router<Data> {
-    pub(crate) fn new() -> Router<Data> {
+    pub fn new() -> Router<Data> {
         Router {
             table: UrlTable::new(),
             middleware: vec![],
@@ -21,8 +47,8 @@ impl<Data> Router<Data> {
     }
 
     /// Add a new resource at `path`.
-    pub fn at<'a>(&'a mut self, path: &'a str) -> &mut Resource<Data> {
-        self.table.setup(path)
+    pub fn at<'a>(&'a mut self, path: &'a str) -> ResourceHandle<'a, Self> {
+        <Self as crate::url_table::Router>::at(self, path)
     }
 
     /// Apply `middleware` to this router.
@@ -35,56 +61,18 @@ impl<Data> Router<Data> {
         &'a self,
         path: &'a str,
         method: &http::Method,
-    ) -> Option<(
-        &'a BoxedEndpoint<Data>,
-        RouteMatch<'a>,
-        Vec<&'a (Middleware<Data> + Send + Sync)>,
-    )> {
-        let mut table = &self.table;
-        let mut params = Vec::new();
-        let mut param_map = HashMap::new();
-        let mut middlewares: Vec<_> = self.middleware.iter().map(|x| &**x).collect();
+    ) -> Option<EndpointInfo<'a, Data>> {
+        let route_result = <Self as crate::url_table::Router>::route(self, path)?;
 
-        for segment in path.split('/') {
-            let result = table.resolve_segment(segment)?;
-            match result {
-                ResolveResult::Segment(next_table) => {
-                    table = next_table;
-                }
-                ResolveResult::Wildcard {
-                    name,
-                    table: next_table,
-                } => {
-                    params.push(segment);
+        let resource = route_result.resource;
+        let params = route_result.route_match;
+        let middleware: Vec<_> = route_result
+            .routers
+            .into_iter()
+            .flat_map(|router| router.middleware.iter().map(|m| &**m))
+            .collect();
 
-                    if !name.is_empty() {
-                        param_map.insert(name, segment);
-                    }
-
-                    table = next_table;
-                }
-            }
-
-            // If the resource is a router, enter it
-            if let Some(Resource(ResourceKind::Nested(router))) = table.root() {
-                table = &router.table;
-                middlewares.extend(router.middleware.iter().map(|x| &**x));
-            }
-        }
-
-        let resource = table.root()?;
-        let route_match = RouteMatch {
-            vec: params,
-            map: param_map,
-        };
-
-        let endpoints = match &resource.0 {
-            ResourceKind::Empty => return None,
-            ResourceKind::Endpoint(endpoints) => endpoints,
-            ResourceKind::Nested(router) => {
-                unreachable!("Router::route should enter subroutes eagerly");
-            }
-        };
+        let endpoints = &resource.endpoints;
 
         // If it is a HTTP HEAD request then check if there is a callback in the endpoints map
         // if not then fallback to the behavior of HTTP GET else proceed as usual
@@ -95,7 +83,11 @@ impl<Data> Router<Data> {
                 endpoints.get(method)
             }?;
 
-        Some((endpoint, route_match, middlewares))
+        Some(EndpointInfo {
+            endpoint,
+            params,
+            middleware,
+        })
     }
 }
 
@@ -103,80 +95,26 @@ impl<Data> Router<Data> {
 ///
 /// All HTTP requests are made against resources. After using `App::at` to establish a resource path,
 /// the `Resource` type can be used to establish endpoints for various HTTP methods at that path.
-pub struct Resource<Data>(ResourceKind<Data>);
+pub struct Resource<Data> {
+    endpoints: HashMap<http::Method, BoxedEndpoint<Data>>,
+}
 
 impl<Data> Default for Resource<Data> {
     fn default() -> Self {
-        Resource(ResourceKind::default())
-    }
-}
-
-enum ResourceKind<Data> {
-    Empty,
-    Endpoint(HashMap<http::Method, BoxedEndpoint<Data>>),
-    Nested(Box<Router<Data>>),
-}
-
-impl<Data> Default for ResourceKind<Data> {
-    fn default() -> Self {
-        ResourceKind::Empty
+        Resource {
+            endpoints: HashMap::new(),
+        }
     }
 }
 
 impl<Data> Resource<Data> {
-    /// Nest a router in this path.
-    pub fn nest<F>(&mut self, builder: F)
-    where
-        F: FnOnce(&mut Router<Data>),
-    {
-        if self.is_nested() {
-            panic!("This path already has a router mounted");
-        }
-        if !self.is_empty() {
-            panic!("This path already has endpoints");
-        }
-
-        let mut router = Router::new();
-        builder(&mut router);
-        self.0 = ResourceKind::Nested(Box::new(router));
-    }
-
-    /// Get whether this path has a router mounted.
-    pub fn is_nested(&self) -> bool {
-        match &self.0 {
-            ResourceKind::Nested(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Get whether this path is empty.
-    pub fn is_empty(&self) -> bool {
-        match self.0 {
-            ResourceKind::Empty => true,
-            _ => false,
-        }
-    }
-
     /// Add an endpoint for the given HTTP method
     pub fn method<T: Endpoint<Data, U>, U>(&mut self, method: http::Method, ep: T) {
-        if let ResourceKind::Empty = self.0 {
-            self.0 = ResourceKind::Endpoint(HashMap::new());
+        if self.endpoints.contains_key(&method) {
+            panic!("A {} endpoint already exists for this path", method)
         }
-        match &mut self.0 {
-            ResourceKind::Endpoint(endpoints) => {
-                if endpoints.contains_key(&method) {
-                    panic!("A {} endpoint already exists for this path", method)
-                }
 
-                endpoints.insert(method, BoxedEndpoint::new(ep));
-            }
-            ResourceKind::Nested(router) => {
-                panic!("This path has a router mounted.");
-            }
-            _ => {
-                unreachable!();
-            }
-        }
+        self.endpoints.insert(method, BoxedEndpoint::new(ep));
     }
 
     /// Add an endpoint for `GET` requests

--- a/src/router.rs
+++ b/src/router.rs
@@ -38,9 +38,8 @@ impl<Data> Router<Data> {
     ) -> Option<(
         &'a BoxedEndpoint<Data>,
         RouteMatch<'a>,
-        Vec<&'a (Middleware<Data> + Send + Sync)>
-    )>
-    {
+        Vec<&'a (Middleware<Data> + Send + Sync)>,
+    )> {
         let mut table = &self.table;
         let mut params = Vec::new();
         let mut param_map = HashMap::new();
@@ -52,7 +51,10 @@ impl<Data> Router<Data> {
                 ResolveResult::Segment(next_table) => {
                     table = next_table;
                 }
-                ResolveResult::Wildcard { name, table: next_table } => {
+                ResolveResult::Wildcard {
+                    name,
+                    table: next_table,
+                } => {
                     params.push(segment);
 
                     if !name.is_empty() {
@@ -79,16 +81,19 @@ impl<Data> Router<Data> {
         let endpoints = match &resource.0 {
             ResourceKind::Empty => return None,
             ResourceKind::Endpoint(endpoints) => endpoints,
-            ResourceKind::Nested(router) => unreachable!("Router::route should enter subroutes eagerly"),
+            ResourceKind::Nested(router) => {
+                unreachable!("Router::route should enter subroutes eagerly");
+            }
         };
 
         // If it is a HTTP HEAD request then check if there is a callback in the endpoints map
         // if not then fallback to the behavior of HTTP GET else proceed as usual
-        let endpoint = if method == http::Method::HEAD && !endpoints.contains_key(&http::Method::HEAD) {
-            endpoints.get(&http::Method::GET)
-        } else {
-            endpoints.get(method)
-        }?;
+        let endpoint =
+            if method == http::Method::HEAD && !endpoints.contains_key(&http::Method::HEAD) {
+                endpoints.get(&http::Method::GET)
+            } else {
+                endpoints.get(method)
+            }?;
 
         Some((endpoint, route_match, middlewares))
     }
@@ -120,7 +125,10 @@ impl<Data> Default for ResourceKind<Data> {
 
 impl<Data> Resource<Data> {
     /// Nest a router in this path.
-    pub fn nest<F>(&mut self, builder: F) where F: FnOnce(&mut Router<Data>) {
+    pub fn nest<F>(&mut self, builder: F)
+    where
+        F: FnOnce(&mut Router<Data>),
+    {
         if self.is_nested() {
             panic!("This path already has a router mounted");
         }

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,37 +2,95 @@ use std::collections::HashMap;
 
 use crate::{
     endpoint::{BoxedEndpoint, Endpoint},
-    url_table::{RouteMatch, UrlTable},
+    url_table::{ResolveResult, RouteMatch, UrlTable},
+    Middleware,
 };
 
-pub(crate) struct Router<Data> {
+/// TODO: Write documentation for `Router`
+pub struct Router<Data> {
     table: UrlTable<Resource<Data>>,
+    middleware: Vec<Box<dyn Middleware<Data> + Send + Sync>>,
 }
 
 impl<Data> Router<Data> {
     pub(crate) fn new() -> Router<Data> {
         Router {
             table: UrlTable::new(),
+            middleware: vec![],
         }
     }
 
-    pub(crate) fn at<'a>(&'a mut self, path: &'a str) -> &mut Resource<Data> {
+    /// Add a new resource at `path`.
+    pub fn at<'a>(&'a mut self, path: &'a str) -> &mut Resource<Data> {
         self.table.setup(path)
+    }
+
+    /// Apply `middleware` to this router.
+    pub fn middleware(&mut self, middleware: impl Middleware<Data> + 'static) -> &mut Self {
+        self.middleware.push(Box::new(middleware));
+        self
     }
 
     pub(crate) fn route<'a>(
         &'a self,
         path: &'a str,
         method: &http::Method,
-    ) -> Option<(&'a BoxedEndpoint<Data>, RouteMatch<'a>)> {
-        let (route, route_match) = self.table.route(path)?;
+    ) -> Option<(
+        &'a BoxedEndpoint<Data>,
+        RouteMatch<'a>,
+        Vec<&'a (Middleware<Data> + Send + Sync)>
+    )>
+    {
+        let mut table = &self.table;
+        let mut params = Vec::new();
+        let mut param_map = HashMap::new();
+        let mut middlewares: Vec<_> = self.middleware.iter().map(|x| &**x).collect();
+
+        for segment in path.split('/') {
+            let result = table.resolve_segment(segment)?;
+            match result {
+                ResolveResult::Segment(next_table) => {
+                    table = next_table;
+                }
+                ResolveResult::Wildcard { name, table: next_table } => {
+                    params.push(segment);
+
+                    if !name.is_empty() {
+                        param_map.insert(name, segment);
+                    }
+
+                    table = next_table;
+                }
+            }
+
+            // If the resource is a router, enter it
+            if let Some(Resource(ResourceKind::Nested(router))) = table.root() {
+                table = &router.table;
+                middlewares.extend(router.middleware.iter().map(|x| &**x));
+            }
+        }
+
+        let resource = table.root()?;
+        let route_match = RouteMatch {
+            vec: params,
+            map: param_map,
+        };
+
+        let endpoints = match &resource.0 {
+            ResourceKind::Empty => return None,
+            ResourceKind::Endpoint(endpoints) => endpoints,
+            ResourceKind::Nested(router) => unreachable!("Router::route should enter subroutes eagerly"),
+        };
+
         // If it is a HTTP HEAD request then check if there is a callback in the endpoints map
         // if not then fallback to the behavior of HTTP GET else proceed as usual
-        if method == http::Method::HEAD && !route.endpoints.contains_key(&http::Method::HEAD) {
-            Some((route.endpoints.get(&http::Method::GET)?, route_match))
+        let endpoint = if method == http::Method::HEAD && !endpoints.contains_key(&http::Method::HEAD) {
+            endpoints.get(&http::Method::GET)
         } else {
-            Some((route.endpoints.get(method)?, route_match))
-        }
+            endpoints.get(method)
+        }?;
+
+        Some((endpoint, route_match, middlewares))
     }
 }
 
@@ -40,26 +98,77 @@ impl<Data> Router<Data> {
 ///
 /// All HTTP requests are made against resources. After using `App::at` to establish a resource path,
 /// the `Resource` type can be used to establish endpoints for various HTTP methods at that path.
-pub struct Resource<Data> {
-    endpoints: HashMap<http::Method, BoxedEndpoint<Data>>,
-}
+pub struct Resource<Data>(ResourceKind<Data>);
 
 impl<Data> Default for Resource<Data> {
     fn default() -> Self {
-        Resource {
-            endpoints: HashMap::new(),
-        }
+        Resource(ResourceKind::default())
+    }
+}
+
+enum ResourceKind<Data> {
+    Empty,
+    Endpoint(HashMap<http::Method, BoxedEndpoint<Data>>),
+    Nested(Box<Router<Data>>),
+}
+
+impl<Data> Default for ResourceKind<Data> {
+    fn default() -> Self {
+        ResourceKind::Empty
     }
 }
 
 impl<Data> Resource<Data> {
-    /// Add an endpoint for the given HTTP method
-    pub fn method<T: Endpoint<Data, U>, U>(&mut self, method: http::Method, ep: T) {
-        if self.endpoints.contains_key(&method) {
-            panic!("A {} endpoint already exists for this path", method)
+    /// Nest a router in this path.
+    pub fn nest<F>(&mut self, builder: F) where F: FnOnce(&mut Router<Data>) {
+        if self.is_nested() {
+            panic!("This path already has a router mounted");
+        }
+        if !self.is_empty() {
+            panic!("This path already has endpoints");
         }
 
-        self.endpoints.insert(method, BoxedEndpoint::new(ep));
+        let mut router = Router::new();
+        builder(&mut router);
+        self.0 = ResourceKind::Nested(Box::new(router));
+    }
+
+    /// Get whether this path has a router mounted.
+    pub fn is_nested(&self) -> bool {
+        match &self.0 {
+            ResourceKind::Nested(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Get whether this path is empty.
+    pub fn is_empty(&self) -> bool {
+        match self.0 {
+            ResourceKind::Empty => true,
+            _ => false,
+        }
+    }
+
+    /// Add an endpoint for the given HTTP method
+    pub fn method<T: Endpoint<Data, U>, U>(&mut self, method: http::Method, ep: T) {
+        if let ResourceKind::Empty = self.0 {
+            self.0 = ResourceKind::Endpoint(HashMap::new());
+        }
+        match &mut self.0 {
+            ResourceKind::Endpoint(endpoints) => {
+                if endpoints.contains_key(&method) {
+                    panic!("A {} endpoint already exists for this path", method)
+                }
+
+                endpoints.insert(method, BoxedEndpoint::new(ep));
+            }
+            ResourceKind::Nested(router) => {
+                panic!("This path has a router mounted.");
+            }
+            _ => {
+                unreachable!();
+            }
+        }
     }
 
     /// Add an endpoint for `GET` requests

--- a/src/url_table.rs
+++ b/src/url_table.rs
@@ -83,7 +83,10 @@ impl<R: Default> UrlTable<R> {
                 ResolveResult::Segment(next_table) => {
                     table = next_table;
                 }
-                ResolveResult::Wildcard { name, table: next_table } => {
+                ResolveResult::Wildcard {
+                    name,
+                    table: next_table,
+                } => {
                     params.push(segment);
 
                     if !name.is_empty() {


### PR DESCRIPTION
An implementation of #4.

Module `url_table` has `Router` trait that performs routing and resource setup, and `GenericRouter` which is a trivial implementation of `Router`.

`router::Router` is an implementation of `url_table::Router`. It is like `GenericRouter` but it also has middlewares.

- [ ] Write documents
- [ ] Add more examples