### PR TITLE
Add form data extraction from body via serde_qs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = "1.0.32"
 typemap = "0.3.3"
+serde_qs = "0.4.1"
 
 [dependencies.futures-preview]
 features = ["compat"]

--- a/examples/body_types.rs
+++ b/examples/body_types.rs
@@ -32,11 +32,18 @@ async fn echo_json(msg: body::Json<Message>) -> body::Json<Message> {
     msg
 }
 
+async fn echo_form(msg: body::Form<Message>) -> body::Form<Message> {
+    println!("Form: {:?}", msg.0);
+
+    msg
+}
+
 fn main() {
     let mut app = tide::App::new(());
     app.at("/echo/string").post(echo_string);
     app.at("/echo/string_lossy").post(echo_string_lossy);
     app.at("/echo/vec").post(echo_vec);
     app.at("/echo/json").post(echo_json);
+    app.at("/echo/form").post(echo_form);
     app.serve("127.0.0.1:8000");
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -150,6 +150,42 @@ impl<T: 'static + Send + serde::Serialize> IntoResponse for Json<T> {
     }
 }
 
+/// A wrapper for form encoded (application/x-www-form-urlencoded) (de)serialization of bodies.
+///
+/// This type is usable both as an extractor (argument to an endpoint) and as a response
+/// (return value from an endpoint), though returning a response with form data is uncommon
+/// and probably not good practice.
+pub struct Form<T>(pub T);
+
+impl<T: Send + serde::de::DeserializeOwned + 'static, S: 'static> Extract<S> for Form<T> {
+    // Note: cannot use `existential type` here due to ICE
+    type Fut = FutureObj<'static, Result<Self, Response>>;
+
+    fn extract(data: &mut S, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+        let mut body = std::mem::replace(req.body_mut(), Body::empty());
+        FutureObj::new(Box::new(
+            async move {
+                let body = await!(body.read_to_vec()).map_err(mk_err)?;
+                let data: T = serde_qs::from_bytes(&body).map_err(mk_err)?;
+                Ok(Form(data))
+            },
+        ))
+    }
+}
+
+impl<T: 'static + Send + serde::Serialize> IntoResponse for Form<T> {
+    fn into_response(self) -> Response {
+        // TODO: think about how to handle errors
+        http::Response::builder()
+            .status(http::status::StatusCode::OK)
+            .header("Content-Type", "Application/x-www-form-urlencoded")
+            .body(Body::from(
+                serde_qs::to_string(&self.0).unwrap().into_bytes(),
+            ))
+            .unwrap()
+    }
+}
+
 pub struct Str(pub String);
 
 impl<S: 'static> Extract<S> for Str {

--- a/src/body.rs
+++ b/src/body.rs
@@ -144,7 +144,7 @@ impl<T: 'static + Send + serde::Serialize> IntoResponse for Json<T> {
         // TODO: think about how to handle errors
         http::Response::builder()
             .status(http::status::StatusCode::OK)
-            .header("Content-Type", "Application/json")
+            .header("Content-Type", "application/json")
             .body(Body::from(serde_json::to_vec(&self.0).unwrap()))
             .unwrap()
     }
@@ -178,7 +178,7 @@ impl<T: 'static + Send + serde::Serialize> IntoResponse for Form<T> {
         // TODO: think about how to handle errors
         http::Response::builder()
             .status(http::status::StatusCode::OK)
-            .header("Content-Type", "Application/x-www-form-urlencoded")
+            .header("Content-Type", "application/x-www-form-urlencoded")
             .body(Body::from(
                 serde_qs::to_string(&self.0).unwrap().into_bytes(),
             ))


### PR DESCRIPTION
An attempt at resolving #22, this seemed almost too easy, so maybe I'm misunderstanding something here 😅

This makes it possible extract `x-www-form-urlencoded` data from the request body via [serde_qs](https://crates.io/crates/serde_qs). 

This means that even nested fields can be extracted via the same `foo[bar]` syntax used in node's qs and Ruby on Rails. This is somewhat of an opinionated decision, but the web ecosystem seems to be converging on this and it is a huge boon when submitting complex form data.

The alternative is only allowing a flat map of key->values but this is very limiting.

Another decision here is the naming of the extractor. Since there are two different form encodings, `application/x-www-form-urlencoded` and `multipart/form-data`<sup>1</sup> it might seem reasonable to name this extractor `body::UrlencodedForm` or something, but I think that choosing the simpler `body::Form` name is the better choice here. The reason being that urlencoded forms are far more common than multipart, and urlencoded is the standard when no encoding is specified. In other words, multipart forms really are a special case, and having both `Form` and `MultipartForm` would make the distinction clear. actix-web makes the same choice here, opting for `Form` and `Multipart` as names.

<sup>1</sup>well technically there is also `text/plain`, but it seems to be mostly useless