### PR TITLE
Subrouters and per-endpoint middleware

### DIFF
--- a/examples/simple_nested_router.rs
+++ b/examples/simple_nested_router.rs
@@ -1,0 +1,37 @@
+// A `Router`-nesting version of the example `named_path`.
+
+#![feature(async_await, futures_api)]
+
+use tide::{
+    head::{Named, NamedComponent},
+    Router,
+};
+
+struct Number(i32);
+
+impl NamedComponent for Number {
+    const NAME: &'static str = "num";
+}
+
+impl std::str::FromStr for Number {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(|num| Number(num))
+    }
+}
+
+async fn add_two(Named(number): Named<Number>) -> String {
+    let Number(num) = number;
+    format!("{} plus two is {}", num, num + 2)
+}
+
+fn build_add_two<Data: Clone + Send + Sync + 'static>(router: &mut Router<Data>) {
+    router.at("{num}").get(add_two);
+}
+
+fn main() {
+    let mut app = tide::App::new(());
+    app.at("add_two").nest(build_add_two);
+    app.serve("127.0.0.1:8000");
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -41,7 +41,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
     }
 
     /// Add a new resource at `path`.
-    pub fn at<'a>(&'a mut self, path: &'a str) -> Resource<Data> {
+    pub fn at<'a>(&'a mut self, path: &'a str) -> Resource<'a, Data> {
         self.router.at(path)
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -41,13 +41,12 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
     }
 
     /// Add a new resource at `path`.
-    ///
-    /// Middlewares added before will be applied to the resource.
     pub fn at<'a>(&'a mut self, path: &'a str) -> Resource<Data> {
         self.router.at(path)
     }
 
-    /// Apply `middleware` to the whole app.
+    /// Apply `middleware` to the whole app. Note that the order of nesting subrouters and applying
+    /// middleware matters; see `Router` for details.
     pub fn middleware(&mut self, middleware: impl Middleware<Data> + 'static) -> &mut Self {
         self.router.middleware(middleware);
         self

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::{
     body::Body,
     extract::Extract,
-    router::{Resource, Router},
+    router::{ResourceHandle, RouteResult, Router},
     Middleware, Request, Response, RouteMatch,
 };
 
@@ -24,7 +24,6 @@ use crate::{
 pub struct App<Data> {
     data: Data,
     router: Router<Data>,
-    middleware: Vec<Box<dyn Middleware<Data> + Send + Sync>>,
 }
 
 impl<Data: Clone + Send + Sync + 'static> App<Data> {
@@ -33,18 +32,24 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
         App {
             data,
             router: Router::new(),
-            middleware: Vec::new(),
         }
     }
 
+    /// Get the top-level router.
+    pub fn router(&mut self) -> &mut Router<Data> {
+        &mut self.router
+    }
+
     /// Add a new resource at `path`.
-    pub fn at<'a>(&'a mut self, path: &'a str) -> &mut Resource<Data> {
+    ///
+    /// Middlewares added before will be applied to the resource.
+    pub fn at<'a>(&'a mut self, path: &'a str) -> ResourceHandle<Data> {
         self.router.at(path)
     }
 
     /// Apply `middleware` to the whole app.
     pub fn middleware(&mut self, middleware: impl Middleware<Data> + 'static) -> &mut Self {
-        self.middleware.push(Box::new(middleware));
+        self.router.middleware(middleware);
         self
     }
 
@@ -52,7 +57,6 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
         Server {
             data: self.data,
             router: Arc::new(self.router),
-            middleware: Arc::new(self.middleware),
         }
     }
 
@@ -84,7 +88,6 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
 struct Server<Data> {
     data: Data,
     router: Arc<Router<Data>>,
-    middleware: Arc<Vec<Box<dyn Middleware<Data> + Send + Sync>>>,
 }
 
 impl<Data: Clone + Send + Sync + 'static> Service for Server<Data> {
@@ -96,7 +99,6 @@ impl<Data: Clone + Send + Sync + 'static> Service for Server<Data> {
     fn call(&mut self, req: http::Request<hyper::Body>) -> Self::Future {
         let mut data = self.data.clone();
         let router = self.router.clone();
-        let middleware = self.middleware.clone();
 
         let mut req = req.map(Body::from);
         let path = req.uri().path().to_owned();
@@ -104,7 +106,12 @@ impl<Data: Clone + Send + Sync + 'static> Service for Server<Data> {
 
         FutureObj::new(Box::new(
             async move {
-                if let Some((endpoint, params)) = router.route(&path, &method) {
+                if let Some(RouteResult {
+                    endpoint,
+                    params,
+                    middleware,
+                }) = router.route(&path, &method)
+                {
                     for m in middleware.iter() {
                         match await!(m.request(&mut data, req, &params)) {
                             Ok(new_req) => req = new_req,

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::{
     body::Body,
     extract::Extract,
-    router::{ResourceHandle, RouteResult, Router},
+    router::{Resource, RouteResult, Router},
     Middleware, Request, Response, RouteMatch,
 };
 
@@ -43,7 +43,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
     /// Add a new resource at `path`.
     ///
     /// Middlewares added before will be applied to the resource.
-    pub fn at<'a>(&'a mut self, path: &'a str) -> ResourceHandle<Data> {
+    pub fn at<'a>(&'a mut self, path: &'a str) -> Resource<Data> {
         self.router.at(path)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,6 @@ pub use crate::{
     middleware::Middleware,
     request::Request,
     response::{IntoResponse, Response},
-    router::Router,
+    router::{Resource, Router},
     url_table::RouteMatch,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,6 @@ pub use crate::{
     middleware::Middleware,
     request::Request,
     response::{IntoResponse, Response},
-    router::{Resource, Router},
+    router::Router,
     url_table::RouteMatch,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,6 @@ pub use crate::{
     middleware::Middleware,
     request::Request,
     response::{IntoResponse, Response},
-    router::Resource,
+    router::{Resource, Router},
     url_table::RouteMatch,
 };

--- a/src/router.rs
+++ b/src/router.rs
@@ -200,7 +200,10 @@ mod tests {
         } = router.route(path, method)?;
 
         let mut data = Data::default();
-        let mut req = Request::new(Body::empty());
+        let mut req = http::Request::builder()
+            .method(method)
+            .body(Body::empty())
+            .unwrap();
         for m in middleware.iter() {
             match await!(m.request(&mut data, req, &params)) {
                 Ok(new_req) => req = new_req,

--- a/src/router.rs
+++ b/src/router.rs
@@ -125,10 +125,7 @@ impl<'a, Data> Resource<'a, Data> {
     /// the builder will be local to the subrouter and its descendents.
     ///
     /// If resources are already present, they will be discarded.
-    pub fn nest<F>(self, builder: F)
-    where
-        F: FnOnce(&mut Router<Data>),
-    {
+    pub fn nest(self, builder: impl FnOnce(&mut Router<Data>)) {
         let mut subrouter = Router {
             idx: self.next_router_idx,
             table: UrlTable::new(),

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,38 +1,125 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::{
     endpoint::{BoxedEndpoint, Endpoint},
     url_table::{RouteMatch, UrlTable},
+    Middleware,
 };
 
-pub(crate) struct Router<Data> {
+/// TODO: Document `Router`
+pub struct Router<Data> {
     table: UrlTable<Resource<Data>>,
+    middleware: Vec<Arc<dyn Middleware<Data> + Send + Sync>>,
+}
+
+pub(crate) struct RouteResult<'a, Data> {
+    pub(crate) endpoint: &'a BoxedEndpoint<Data>,
+    pub(crate) params: RouteMatch<'a>,
+    pub(crate) middleware: &'a [Arc<dyn Middleware<Data> + Send + Sync>],
+}
+
+impl<Data> Default for Router<Data> {
+    fn default() -> Router<Data> {
+        Router::new()
+    }
 }
 
 impl<Data> Router<Data> {
     pub(crate) fn new() -> Router<Data> {
         Router {
             table: UrlTable::new(),
+            middleware: Vec::new(),
         }
     }
 
-    pub(crate) fn at<'a>(&'a mut self, path: &'a str) -> &mut Resource<Data> {
-        self.table.setup(path)
+    /// Add a new resource at `path`, relative to this router.
+    ///
+    /// Middlewares added before will be applied to the resource.
+    pub fn at<'a>(&'a mut self, path: &'a str) -> ResourceHandle<'a, Data> {
+        let table = self.table.setup_table(path);
+        let middleware = &*self.middleware;
+        ResourceHandle { table, middleware }
+    }
+
+    /// Add `middleware` to this router.
+    pub fn middleware(&mut self, middleware: impl Middleware<Data> + 'static) -> &mut Self {
+        self.middleware.push(Arc::new(middleware));
+        self
     }
 
     pub(crate) fn route<'a>(
         &'a self,
         path: &'a str,
         method: &http::Method,
-    ) -> Option<(&'a BoxedEndpoint<Data>, RouteMatch<'a>)> {
+    ) -> Option<RouteResult<'a, Data>> {
         let (route, route_match) = self.table.route(path)?;
         // If it is a HTTP HEAD request then check if there is a callback in the endpoints map
         // if not then fallback to the behavior of HTTP GET else proceed as usual
-        if method == http::Method::HEAD && !route.endpoints.contains_key(&http::Method::HEAD) {
-            Some((route.endpoints.get(&http::Method::GET)?, route_match))
-        } else {
-            Some((route.endpoints.get(method)?, route_match))
+        let endpoint =
+            if method == http::Method::HEAD && !route.endpoints.contains_key(&http::Method::HEAD) {
+                route.endpoints.get(&http::Method::GET)?
+            } else {
+                route.endpoints.get(method)?
+            };
+        let middleware = &*route.middleware;
+
+        Some(RouteResult {
+            endpoint,
+            params: route_match,
+            middleware,
+        })
+    }
+}
+
+/// A struct representing specific path of a router.
+///
+/// The struct implements `Deref` and `DerefMut` into `Resource`. You can use this to add a
+/// resource to the path.
+///
+/// Also, using `nest`, you can set up a subrouter for the path.
+pub struct ResourceHandle<'a, Data> {
+    table: &'a mut UrlTable<Resource<Data>>,
+    middleware: &'a [Arc<dyn Middleware<Data> + Send + Sync>],
+}
+
+impl<'a, Data> ResourceHandle<'a, Data> {
+    /// "Nest" a subrouter to the path.
+    pub fn nest<F>(self, builder: F)
+    where
+        F: FnOnce(&mut Router<Data>),
+    {
+        let mut subrouter = Router {
+            table: UrlTable::new(),
+            middleware: self.middleware.to_vec(),
+        };
+        builder(&mut subrouter);
+        std::mem::swap(self.table, &mut subrouter.table);
+    }
+}
+
+impl<'a, Data> std::ops::Deref for ResourceHandle<'a, Data> {
+    type Target = Resource<Data>;
+
+    fn deref(&self) -> &Resource<Data> {
+        self.table
+            .resource()
+            .expect("Resource of this path has not been initialized.")
+    }
+}
+
+impl<'a, Data> std::ops::DerefMut for ResourceHandle<'a, Data> {
+    fn deref_mut(&mut self) -> &mut Resource<Data> {
+        let resource = self.table.resource_mut();
+        if resource.is_none() {
+            let new_resource = Resource {
+                endpoints: HashMap::new(),
+                middleware: self.middleware.to_vec(),
+            };
+            *resource = Some(new_resource);
         }
+
+        resource.as_mut().unwrap()
     }
 }
 
@@ -42,14 +129,7 @@ impl<Data> Router<Data> {
 /// the `Resource` type can be used to establish endpoints for various HTTP methods at that path.
 pub struct Resource<Data> {
     endpoints: HashMap<http::Method, BoxedEndpoint<Data>>,
-}
-
-impl<Data> Default for Resource<Data> {
-    fn default() -> Self {
-        Resource {
-            endpoints: HashMap::new(),
-        }
-    }
+    middleware: Vec<Arc<dyn Middleware<Data> + Send + Sync>>,
 }
 
 impl<Data> Resource<Data> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -89,6 +89,10 @@ impl<'a, Data> ResourceHandle<'a, Data> {
     where
         F: FnOnce(&mut Router<Data>),
     {
+        if self.table.resource().is_some() {
+            panic!("This path already has a resource");
+        }
+
         let mut subrouter = Router {
             table: UrlTable::new(),
             middleware: self.middleware.to_vec(),


### PR DESCRIPTION
Here is the new design, taking ideas of @aturon from #43. An implementation of #4. (Resolves #4)

* Subrouter support is implemented in `router::Router`, using `router::ResourceHandle`.
* Only middlewares **before** the call of `Router::at()` will be applied to the path (resources and subrouters.)

- [x] It would be good to add some examples that demonstrate subrouters and middlewares. (Done with tests and docs)

---