### PR TITLE
Allow handle file upload via multipart form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = "1.0.80"
 serde_json = "1.0.32"
 typemap = "0.3.3"
 serde_qs = "0.4.1"
+multipart = "0.15.3"
 
 [dependencies.futures-preview]
 features = ["compat"]

--- a/examples/multipart-form/main.rs
+++ b/examples/multipart-form/main.rs
@@ -1,0 +1,74 @@
+#![feature(async_await, futures_api)]
+
+#[macro_use]
+extern crate serde_derive;
+
+use http::status::StatusCode;
+use std::io::Read;
+use tide::{body, App};
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Message {
+    key1: Option<String>,
+    key2: Option<String>,
+    file: Option<String>,
+}
+
+async fn upload_file(
+    multipart_form: body::MultipartForm,
+) -> Result<body::Json<Message>, StatusCode> {
+    // https://stackoverflow.com/questions/43424982/how-to-parse-multipart-forms-using-abonander-multipart-with-rocket
+    let mut message = Message {
+        key1: None,
+        key2: None,
+        file: None,
+    };
+
+    let mut multipart = multipart_form.0;
+    multipart
+        .foreach_entry(|mut entry| match entry.headers.name.as_str() {
+            "file" => {
+                let mut vec = Vec::new();
+                entry.data.read_to_end(&mut vec).expect("can't read");
+                message.file = String::from_utf8(vec).ok();
+                println!("key file got");
+            }
+
+            "key1" => {
+                let mut vec = Vec::new();
+                entry.data.read_to_end(&mut vec).expect("can't read");
+                message.key1 = String::from_utf8(vec).ok();
+                println!("key1 got");
+            }
+
+            "key2" => {
+                let mut vec = Vec::new();
+                entry.data.read_to_end(&mut vec).expect("can't read");
+                message.key2 = String::from_utf8(vec).ok();
+                println!("key2 got");
+            }
+
+            _ => {
+                // as multipart has a bug https://github.com/abonander/multipart/issues/114
+                // we manually do read_to_end here
+                let mut _vec = Vec::new();
+                entry.data.read_to_end(&mut _vec).expect("can't read");
+                println!("key neglected");
+            }
+        })
+        .expect("Unable to iterate multipart?");
+
+    Ok(body::Json(message))
+}
+
+fn main() {
+    let mut app = App::new(());
+
+    app.at("/upload_file").post(upload_file);
+
+    app.serve("127.0.0.1:7878");
+}
+
+// Test with:
+// curl -X POST http://localhost:7878/upload_file -H 'content-type: multipart/form-data' -F file=@examples/multipart-form/test.txt
+// curl -X POST http://localhost:7878/upload_file -H 'content-type: multipart/form-data' -F key1=v1, -F key2=v2

--- a/examples/multipart-form/test.txt
+++ b/examples/multipart-form/test.txt
@@ -1,0 +1,1 @@
+This is a test file.

--- a/src/head.rs
+++ b/src/head.rs
@@ -44,6 +44,11 @@ impl Head {
     pub fn method(&self) -> &http::Method {
         &self.inner.method
     }
+
+    /// The HTTP headers
+    pub fn headers(&self) -> &http::header::HeaderMap<http::header::HeaderValue> {
+        &self.inner.headers
+    }
 }
 
 /// An extractor for path components.


### PR DESCRIPTION
Hi there, not at all an expert here but I would like to try help a bit if I can.

Do you think either one of the two methods I provided here could be a good way of handling multipart form file-upload? 

(I used some idea from here: https://github.com/rust-net-web/tide/pull/44)

The differences between the two methods I mentioned here are: (see the example first)
* `form_auto` use a new body type created in `body::MultipartFile` to allow user of tide easier get a `Vec<u8>` of the file uploaded.
* `form_manual` use a new head type `head::NamedHeader` to allow user get header "content-type" and raw body as `Vec<u8>` then manually use the `multipart` crate method to get what he want. 

Not sure whether I am heading the correct direction here but I would like to hear your opinion. I am kind of new to Rust, BTW 😆 