### PR TITLE
Relieve middleware FutureObj lifetime bounds

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -106,7 +106,7 @@ impl<Data: Clone + Send + Sync + 'static> Service for Server<Data> {
             async move {
                 if let Some((endpoint, params)) = router.route(&path, &method) {
                     for m in middleware.iter() {
-                        if let Some(resp) = await!(m.request(&mut data, &mut req, &params)) {
+                        if let Err(resp) = await!(m.request(&mut data, &mut req, &params)) {
                             return Ok(resp.map(Into::into));
                         }
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,16 +106,15 @@ impl<Data: Clone + Send + Sync + 'static> Service for Server<Data> {
             async move {
                 if let Some((endpoint, params)) = router.route(&path, &method) {
                     for m in middleware.iter() {
-                        match await!(m.request(&mut data, req, &params)) {
-                            Ok(new_req) => req = new_req,
-                            Err(resp) => return Ok(resp.map(Into::into)),
+                        if let Some(resp) = await!(m.request(&mut data, &mut req, &params)) {
+                            return Ok(resp.map(Into::into));
                         }
                     }
 
                     let (head, mut resp) = await!(endpoint.call(data.clone(), req, params));
 
                     for m in middleware.iter() {
-                        resp = await!(m.response(&mut data, &head, resp))
+                        await!(m.response(&mut data, &head, &mut resp));
                     }
 
                     Ok(resp.map(Into::into))

--- a/src/middleware/default_headers.rs
+++ b/src/middleware/default_headers.rs
@@ -34,16 +34,19 @@ impl DefaultHeaders {
 }
 
 impl<Data> Middleware<Data> for DefaultHeaders {
-    fn response(
-        &self,
-        data: &mut Data,
-        head: &Head,
-        mut resp: Response,
-    ) -> FutureObj<'static, Response> {
-        let headers = resp.headers_mut();
-        for (key, value) in self.headers.iter() {
-            headers.entry(key).unwrap().or_insert_with(|| value.clone());
-        }
-        FutureObj::new(Box::new(async { resp }))
+    fn response<'a>(
+        &'a self,
+        data: &'a mut Data,
+        head: &'a Head,
+        resp: &'a mut Response,
+    ) -> FutureObj<'a, ()> {
+        FutureObj::new(Box::new(
+            async move {
+                let headers = resp.headers_mut();
+                for (key, value) in self.headers.iter() {
+                    headers.entry(key).unwrap().or_insert_with(|| value.clone());
+                }
+            },
+        ))
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -15,8 +15,8 @@ pub trait Middleware<Data>: Send + Sync {
         data: &'a mut Data,
         req: &'a mut Request,
         params: &'a RouteMatch<'_>,
-    ) -> FutureObj<'a, Option<Response>> {
-        FutureObj::new(Box::new(async { None }))
+    ) -> FutureObj<'a, Result<(), Response>> {
+        FutureObj::new(Box::new(async { Ok(()) }))
     }
 
     /// Asynchronously transform the outgoing response.

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -10,23 +10,23 @@ pub use self::default_headers::DefaultHeaders;
 pub trait Middleware<Data>: Send + Sync {
     /// Asynchronously transform the incoming request, or abort further handling by immediately
     /// returning a response.
-    fn request(
-        &self,
-        data: &mut Data,
-        req: Request,
-        params: &RouteMatch<'_>,
-    ) -> FutureObj<'static, Result<Request, Response>> {
-        FutureObj::new(Box::new(async { Ok(req) }))
+    fn request<'a>(
+        &'a self,
+        data: &'a mut Data,
+        req: &'a mut Request,
+        params: &'a RouteMatch<'_>,
+    ) -> FutureObj<'a, Option<Response>> {
+        FutureObj::new(Box::new(async { None }))
     }
 
     /// Asynchronously transform the outgoing response.
-    fn response(
-        &self,
-        data: &mut Data,
-        head: &Head,
-        resp: Response,
-    ) -> FutureObj<'static, Response> {
-        FutureObj::new(Box::new(async { resp }))
+    fn response<'a>(
+        &'a self,
+        data: &'a mut Data,
+        head: &'a Head,
+        resp: &'a mut Response,
+    ) -> FutureObj<'a, ()> {
+        FutureObj::new(Box::new(async {}))
     }
 
     // TODO: provide the following, intended to fire *after* the body has been fully sent


### PR DESCRIPTION
Side effect: `Request` and `Response` will be given by reference.