### PR TITLE
Extract `url_table` into `path_table` crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rust:
 before_script: |
   rustup component add rustfmt-preview clippy-preview
 script: |
-  cargo fmt -- --check &&
-  cargo clippy -- -D clippy::all &&
-  cargo build --verbose &&
-  cargo test  --verbose
+  cargo fmt --all -- --check &&
+  cargo clippy --all -- -D clippy::all &&
+  cargo build --all --verbose &&
+  cargo test  --all --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/yoshuawuyts/tide"
 version = "0.0.0"
 
+[workspace]
+members = ["path_table"]
+
 [dependencies]
 http = "0.1"
 hyper = "0.12.0"
@@ -22,6 +25,9 @@ serde_json = "1.0.32"
 typemap = "0.3.3"
 serde_qs = "0.4.1"
 multipart = "0.15.3"
+
+[dependencies.path_table]
+path = "path_table"
 
 [dependencies.futures-preview]
 features = ["compat"]

--- a/path_table/Cargo.toml
+++ b/path_table/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "path_table"
+version = "0.0.0"
+description = "Path-based routing table"
+authors = [
+    "Aaron Turon <aturon@mozilla.com>",
+    "Yoshua Wuyts <yoshuawuyts@gmail.com>",
+]
+documentation = "https://docs.rs/path_table"
+repository = "https://github.com/rust-net-web/tide"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]

--- a/path_table/src/lib.rs
+++ b/path_table/src/lib.rs
@@ -411,7 +411,10 @@ mod test {
 
         let (_, params) = table.route("foo/a/b").unwrap();
         assert_eq!(params.vec, &["a", "b"]);
-        assert_eq!(params.map, [("foo", "a"), ("bar", "b")].iter().cloned().collect());
+        assert_eq!(
+            params.map,
+            [("foo", "a"), ("bar", "b")].iter().cloned().collect()
+        );
 
         let (_, params) = table.route("c").unwrap();
         assert_eq!(params.vec, &["c"]);

--- a/path_table/src/lib.rs
+++ b/path_table/src/lib.rs
@@ -66,6 +66,12 @@ impl<R> std::fmt::Debug for PathTable<R> {
     }
 }
 
+impl<R> Default for PathTable<R> {
+    fn default() -> Self {
+        PathTable::new()
+    }
+}
+
 impl<R> PathTable<R> {
     /// Create an empty routing table.
     pub fn new() -> PathTable<R> {

--- a/path_table/src/lib.rs
+++ b/path_table/src/lib.rs
@@ -1,52 +1,52 @@
-//! Generic types for URL routing.
-//!
-//! Intended to eventually be pulled into a separate crate.
+//! Generic types for path-based routing.
 
 use std::collections::HashMap;
 
-/// A generic URL routing table, terminating with resources `R`.
+/// A generic path-based routing table, terminating with resources `R`.
 //
-// The implementation uses a very simple-minded tree structure. `UrlTable` is a node,
+// The implementation uses a very simple-minded tree structure. `PathTable` is a node,
 // with branches corresponding to the next path segment. For concrete segments, the
 // `next` table gives the available string matches. For the (at most one) wildcard match,
 // the `wildcard` field contains the branch.
 //
-// If the current URL itself is a route, the `accept` field says what resource it contains.
-pub struct UrlTable<R> {
+// If the current path itself is a route, the `accept` field says what resource it contains.
+#[derive(Clone)]
+pub struct PathTable<R> {
     accept: Option<R>,
-    next: HashMap<String, UrlTable<R>>,
+    next: HashMap<String, PathTable<R>>,
     wildcard: Option<Box<Wildcard<R>>>,
 }
 
+#[derive(Clone)]
 struct Wildcard<R> {
     name: String,
-    table: UrlTable<R>,
+    table: PathTable<R>,
 }
 
 /// For a successful match, this structure says how any wildcard components were matched.
-///
-/// The `vec` field places the matches in the order they appeared in the URL.
-/// The `map` component contains any named wildcards (`{foo}`) indexed by name.
+#[derive(Debug)]
 pub struct RouteMatch<'a> {
+    /// Wildcard matches in the order they appeared in the path.
     pub vec: Vec<&'a str>,
+    /// Named wildcard matches, indexed by name.
     pub map: HashMap<&'a str, &'a str>,
 }
 
-impl<R> std::fmt::Debug for UrlTable<R> {
+impl<R> std::fmt::Debug for PathTable<R> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        struct Children<'a, R>(&'a HashMap<String, UrlTable<R>>, Option<&'a Wildcard<R>>);
+        struct Children<'a, R>(&'a HashMap<String, PathTable<R>>, Option<&'a Wildcard<R>>);
         impl<'a, R> std::fmt::Debug for Children<'a, R> {
             fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
                 let mut dbg = fmt.debug_map();
                 dbg.entries(self.0.iter());
                 if let Some(wildcard) = self.1 {
-                    dbg.entry(&format!("{{{}}}", wildcard.name), &wildcard.table);
+                    dbg.entry(&format_args!("{{{}}}", wildcard.name), &wildcard.table);
                 }
                 dbg.finish()
             }
         }
 
-        fmt.debug_struct("UrlTable")
+        fmt.debug_struct("PathTable")
             .field(
                 "resource",
                 &format_args!(
@@ -66,10 +66,10 @@ impl<R> std::fmt::Debug for UrlTable<R> {
     }
 }
 
-impl<R> UrlTable<R> {
+impl<R> PathTable<R> {
     /// Create an empty routing table.
-    pub fn new() -> UrlTable<R> {
-        UrlTable {
+    pub fn new() -> PathTable<R> {
+        PathTable {
             accept: None,
             next: HashMap::new(),
             wildcard: None,
@@ -77,7 +77,6 @@ impl<R> UrlTable<R> {
     }
 
     /// Get the resource of current path.
-    #[allow(dead_code)]
     pub fn resource(&self) -> Option<&R> {
         self.accept.as_ref()
     }
@@ -88,17 +87,16 @@ impl<R> UrlTable<R> {
     }
 
     /// Return an iterator of all resources.
-    #[allow(dead_code)]
-    pub fn resources(&self) -> Resources<R> {
+    pub fn iter(&self) -> Resources<R> {
         Resources { stack: vec![self] }
     }
 
-    /// Return an iterator of mutable references all resources.
-    pub fn resources_mut(&mut self) -> ResourcesMut<R> {
+    /// Return a mutable iterator of all resources.
+    pub fn iter_mut(&mut self) -> ResourcesMut<R> {
         ResourcesMut { stack: vec![self] }
     }
 
-    /// Determine which resource, if any, the conrete `path` should be routed to.
+    /// Determine which resource, if any, the concrete `path` should be routed to.
     pub fn route<'a>(&'a self, path: &'a str) -> Option<(&'a R, RouteMatch<'a>)> {
         let mut table = self;
         let mut params = Vec::new();
@@ -142,7 +140,7 @@ impl<R> UrlTable<R> {
     /// Return the table of the given routing path (which may contain wildcards).
     ///
     /// If it doesn't already exist, this will make a new one.
-    pub fn setup_table(&mut self, path: &str) -> &mut UrlTable<R> {
+    pub fn setup_table(&mut self, path: &str) -> &mut PathTable<R> {
         let mut table = self;
         for segment in path.split('/') {
             if segment.is_empty() {
@@ -155,7 +153,7 @@ impl<R> UrlTable<R> {
                 if table.wildcard.is_none() {
                     table.wildcard = Some(Box::new(Wildcard {
                         name: name.to_string(),
-                        table: UrlTable::new(),
+                        table: PathTable::new(),
                     }));
                 }
 
@@ -171,7 +169,7 @@ impl<R> UrlTable<R> {
                 table = table
                     .next
                     .entry(segment.to_string())
-                    .or_insert_with(UrlTable::new);
+                    .or_insert_with(PathTable::new);
             }
         }
 
@@ -179,9 +177,8 @@ impl<R> UrlTable<R> {
     }
 }
 
-impl<R: Default> UrlTable<R> {
+impl<R: Default> PathTable<R> {
     /// Add or access a new resource at the given routing path (which may contain wildcards).
-    #[allow(dead_code)]
     pub fn setup(&mut self, path: &str) -> &mut R {
         let table = self.setup_table(path);
 
@@ -193,8 +190,9 @@ impl<R: Default> UrlTable<R> {
     }
 }
 
+/// An iterator over the resources of a `PathTable`.
 pub struct Resources<'a, R> {
-    stack: Vec<&'a UrlTable<R>>,
+    stack: Vec<&'a PathTable<R>>,
 }
 
 impl<'a, R> Iterator for Resources<'a, R> {
@@ -214,8 +212,9 @@ impl<'a, R> Iterator for Resources<'a, R> {
     }
 }
 
+/// A mutable iterator over the resources of a `PathTable`.
 pub struct ResourcesMut<'a, R> {
-    stack: Vec<&'a mut UrlTable<R>>,
+    stack: Vec<&'a mut PathTable<R>>,
 }
 
 impl<'a, R> Iterator for ResourcesMut<'a, R> {
@@ -237,11 +236,13 @@ impl<'a, R> Iterator for ResourcesMut<'a, R> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use super::*;
 
     #[test]
     fn empty_route_no_matches() {
-        let table: UrlTable<()> = UrlTable::new();
+        let table: PathTable<()> = PathTable::new();
 
         assert!(table.route("").is_none());
         assert!(table.route("/").is_none());
@@ -252,7 +253,7 @@ mod test {
 
     #[test]
     fn root_matches() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("/");
 
         assert!(table.route("").is_some());
@@ -265,7 +266,7 @@ mod test {
 
     #[test]
     fn one_fixed_segment_matches() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("foo");
 
         assert!(table.route("").is_none());
@@ -284,7 +285,7 @@ mod test {
 
     #[test]
     fn multiple_fixed_segment_matches() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("foo");
         table.setup("bar");
 
@@ -301,7 +302,7 @@ mod test {
 
     #[test]
     fn nested_fixed_segment_matches() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("foo/bar");
 
         assert!(table.route("").is_none());
@@ -312,7 +313,7 @@ mod test {
 
     #[test]
     fn multiple_nested_fixed_segment_matches() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("foo/bar");
         table.setup("baz");
         table.setup("quux/twiddle/twibble");
@@ -328,7 +329,7 @@ mod test {
 
     #[test]
     fn overlap_nested_fixed_segment_matches() {
-        let mut table: UrlTable<i32> = UrlTable::new();
+        let mut table: PathTable<i32> = PathTable::new();
         *table.setup("") = 0;
         *table.setup("foo") = 1;
         *table.setup("foo/bar") = 2;
@@ -344,7 +345,7 @@ mod test {
 
     #[test]
     fn wildcard_matches() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("{}");
 
         assert!(table.route("").is_none());
@@ -356,7 +357,7 @@ mod test {
 
     #[test]
     fn nested_wildcard_matches() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("{}/{}");
 
         assert!(table.route("").is_none());
@@ -369,7 +370,7 @@ mod test {
 
     #[test]
     fn mixed_route() {
-        let mut table: UrlTable<()> = UrlTable::new();
+        let mut table: PathTable<()> = PathTable::new();
         table.setup("foo/{}/bar");
 
         assert!(table.route("").is_none());
@@ -383,7 +384,7 @@ mod test {
 
     #[test]
     fn wildcard_fallback() {
-        let mut table: UrlTable<i32> = UrlTable::new();
+        let mut table: PathTable<i32> = PathTable::new();
         *table.setup("foo") = 0;
         *table.setup("foo/bar") = 1;
         *table.setup("foo/{}/bar") = 2;
@@ -395,5 +396,59 @@ mod test {
         assert_eq!(*table.route("foo").unwrap().0, 0);
         assert_eq!(*table.route("foo/bar").unwrap().0, 1);
         assert_eq!(*table.route("foo/baz/bar").unwrap().0, 2);
+    }
+
+    #[test]
+    fn named_wildcard() {
+        let mut table: PathTable<()> = PathTable::new();
+        *table.setup("foo/{foo}");
+        *table.setup("foo/{foo}/{bar}");
+        *table.setup("{}");
+
+        let (_, params) = table.route("foo/a").unwrap();
+        assert_eq!(params.vec, &["a"]);
+        assert_eq!(params.map, [("foo", "a")].iter().cloned().collect());
+
+        let (_, params) = table.route("foo/a/b").unwrap();
+        assert_eq!(params.vec, &["a", "b"]);
+        assert_eq!(params.map, [("foo", "a"), ("bar", "b")].iter().cloned().collect());
+
+        let (_, params) = table.route("c").unwrap();
+        assert_eq!(params.vec, &["c"]);
+        assert!(params.map.is_empty());
+    }
+
+    #[test]
+    #[should_panic]
+    fn conflicting_wildcard_fails() {
+        let mut table: PathTable<()> = PathTable::new();
+        *table.setup("foo/{foo}");
+        *table.setup("foo/{bar}");
+    }
+
+    #[test]
+    fn iter() {
+        let mut table: PathTable<usize> = PathTable::new();
+        *table.setup("foo") = 1;
+        *table.setup("foo/bar") = 2;
+        *table.setup("{}") = 3;
+
+        let set: HashSet<_> = table.iter().cloned().collect();
+        assert_eq!(set, [1, 2, 3].iter().cloned().collect());
+    }
+
+    #[test]
+    fn iter_mut() {
+        let mut table: PathTable<usize> = PathTable::new();
+        *table.setup("foo") = 1;
+        *table.setup("foo/bar") = 2;
+        *table.setup("{}") = 3;
+
+        for res in table.iter_mut() {
+            *res -= 1;
+        }
+
+        let set: HashSet<_> = table.iter().cloned().collect();
+        assert_eq!(set, [0, 1, 2].iter().cloned().collect());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub mod middleware;
 mod request;
 mod response;
 mod router;
-mod url_table;
 
+pub use path_table::RouteMatch;
 pub use crate::{
     app::{App, AppData},
     endpoint::Endpoint,
@@ -31,5 +31,4 @@ pub use crate::{
     request::Request,
     response::{IntoResponse, Response},
     router::{Resource, Router},
-    url_table::RouteMatch,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ mod request;
 mod response;
 mod router;
 
-pub use path_table::RouteMatch;
 pub use crate::{
     app::{App, AppData},
     endpoint::Endpoint,
@@ -32,3 +31,4 @@ pub use crate::{
     response::{IntoResponse, Response},
     router::{Resource, Router},
 };
+pub use path_table::RouteMatch;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use path_table::{PathTable, RouteMatch};
 use crate::{
     endpoint::{BoxedEndpoint, Endpoint},
     Middleware,
 };
+use path_table::{PathTable, RouteMatch};
 
 /// A core type for routing.
 ///

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use path_table::{PathTable, RouteMatch};
 use crate::{
     endpoint::{BoxedEndpoint, Endpoint},
-    url_table::{RouteMatch, UrlTable},
     Middleware,
 };
 
@@ -11,7 +11,7 @@ use crate::{
 ///
 /// The `Router` type can be used to set up routes and resources, and to apply middleware.
 pub struct Router<Data> {
-    table: UrlTable<ResourceData<Data>>,
+    table: PathTable<ResourceData<Data>>,
     middleware_base: Vec<Arc<dyn Middleware<Data> + Send + Sync>>,
 }
 
@@ -25,7 +25,7 @@ impl<Data: Clone + Send + Sync + 'static> Router<Data> {
     /// Create a new top-level router.
     pub(crate) fn new() -> Router<Data> {
         Router {
-            table: UrlTable::new(),
+            table: PathTable::new(),
             middleware_base: Vec::new(),
         }
     }
@@ -69,7 +69,7 @@ impl<Data: Clone + Send + Sync + 'static> Router<Data> {
     /// ```
     pub fn middleware(&mut self, middleware: impl Middleware<Data> + 'static) -> &mut Self {
         let middleware = Arc::new(middleware);
-        for resource in self.table.resources_mut() {
+        for resource in self.table.iter_mut() {
             resource.middleware.push(middleware.clone());
         }
         self.middleware_base.push(middleware);
@@ -100,13 +100,13 @@ impl<Data: Clone + Send + Sync + 'static> Router<Data> {
     }
 }
 
-/// A handle to a resource (identified by a URL).
+/// A handle to a resource (identified by a path).
 ///
 /// All HTTP requests are made against resources. After using `Router::at` (or `App::at`) to
 /// establish a resource path, the `Resource` type can be used to establish endpoints for various
 /// HTTP methods at that path. Also, using `nest`, it can be used to set up a subrouter.
 pub struct Resource<'a, Data> {
-    table: &'a mut UrlTable<ResourceData<Data>>,
+    table: &'a mut PathTable<ResourceData<Data>>,
     middleware_base: &'a Vec<Arc<dyn Middleware<Data> + Send + Sync>>,
 }
 
@@ -125,7 +125,7 @@ impl<'a, Data> Resource<'a, Data> {
     /// If resources are already present, they will be discarded.
     pub fn nest(self, builder: impl FnOnce(&mut Router<Data>)) {
         let mut subrouter = Router {
-            table: UrlTable::new(),
+            table: PathTable::new(),
             middleware_base: self.middleware_base.clone(),
         };
         builder(&mut subrouter);


### PR DESCRIPTION
Resolves #2.

Renamed `url_table` to `path_table` as "URL" feels like a broader term than "path" (which the crate is actually dealing with).