### PR TITLE
Default Handler Implementation

### DIFF
--- a/examples/default_handler.rs
+++ b/examples/default_handler.rs
@@ -15,5 +15,7 @@ fn main() {
             .unwrap()
     });
 
-    app.serve("127.0.0.1:7878")
+    let address = "127.0.0.1:8000".to_owned();
+    println!("Server is listening on http://{}", address);
+    app.serve(address)
 }

--- a/examples/default_handler.rs
+++ b/examples/default_handler.rs
@@ -1,0 +1,19 @@
+#![feature(async_await)]
+
+use http::status::StatusCode;
+use tide::body;
+
+fn main() {
+    let mut app = tide::App::new(());
+    app.at("/").get(async || "Hello, world!");
+
+    app.default_handler(async || {
+        http::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .header("Content-Type", "text/plain")
+            .body(body::Body::from("¯\\_(ツ)_/¯".to_string().into_bytes()))
+            .unwrap()
+    });
+
+    app.serve("127.0.0.1:7878")
+}

--- a/path_table/src/lib.rs
+++ b/path_table/src/lib.rs
@@ -32,6 +32,15 @@ pub struct RouteMatch<'a> {
     pub map: HashMap<&'a str, &'a str>,
 }
 
+impl<'a> RouteMatch<'a> {
+    pub fn empty() -> Self {
+        RouteMatch {
+            vec: Vec::new(),
+            map: HashMap::new(),
+        }
+    }
+}
+
 impl<R> std::fmt::Debug for PathTable<R> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         struct Children<'a, R>(&'a HashMap<String, PathTable<R>>, Option<&'a Wildcard<R>>);

--- a/path_table/src/lib.rs
+++ b/path_table/src/lib.rs
@@ -32,15 +32,6 @@ pub struct RouteMatch<'a> {
     pub map: HashMap<&'a str, &'a str>,
 }
 
-impl<'a> RouteMatch<'a> {
-    pub fn empty() -> Self {
-        RouteMatch {
-            vec: Vec::new(),
-            map: HashMap::new(),
-        }
-    }
-}
-
 impl<R> std::fmt::Debug for PathTable<R> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         struct Children<'a, R>(&'a HashMap<String, PathTable<R>>, Option<&'a Wildcard<R>>);

--- a/src/app.rs
+++ b/src/app.rs
@@ -160,7 +160,7 @@ impl<T> DerefMut for AppData<T> {
 
 impl<T: Clone + Send + 'static> Extract<T> for AppData<T> {
     type Fut = future::Ready<Result<Self, Response>>;
-    fn extract(data: &mut T, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut T, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         future::ok(AppData(data.clone()))
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct App<Data> {
     data: Data,
     router: Router<Data>,
-    default_handler: Arc<BoxedEndpoint<Data>>,
+    default_handler: BoxedEndpoint<Data>,
 }
 
 impl<Data: Clone + Send + Sync + 'static> App<Data> {
@@ -37,9 +37,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
         let mut app = App {
             data,
             router: Router::new(),
-            default_handler: Arc::new(BoxedEndpoint::new(async || {
-                http::status::StatusCode::NOT_FOUND
-            })),
+            default_handler: BoxedEndpoint::new(async || http::status::StatusCode::NOT_FOUND),
         };
 
         // Add RootLogger as a default middleware
@@ -60,7 +58,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
 
     /// Set the default handler for the app, a fallback function when there is no match to the route requested
     pub fn default_handler<T: Endpoint<Data, U>, U>(&mut self, handler: T) -> &mut Self {
-        self.default_handler = Arc::new(BoxedEndpoint::new(handler));
+        self.default_handler = BoxedEndpoint::new(handler);
         self
     }
 
@@ -75,7 +73,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
         Server {
             data: self.data,
             router: Arc::new(self.router),
-            default_handler: Arc::clone(&self.default_handler),
+            default_handler: Arc::new(self.default_handler),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,6 +53,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
         self.router.at(path)
     }
 
+    /// Set the default handler for the app, a fallback function when there is no match to the route requested
     pub fn default_handler<T: Endpoint<Data, U>, U>(&mut self, ep: T) -> &mut Self {
         self.router.set_default_handler(ep);
         self

--- a/src/body.rs
+++ b/src/body.rs
@@ -17,6 +17,7 @@ use crate::{Extract, IntoResponse, Request, Response, RouteMatch};
 /// A body is a stream of `BodyChunk`s, which are essentially `Vec<u8>` values.
 /// Both `Body` and `BodyChunk` values can be easily created from standard byte buffer types,
 /// using the `From` trait.
+#[derive(Debug)]
 pub struct Body {
     inner: BodyInner,
 }
@@ -43,6 +44,7 @@ impl From<String> for BodyChunk {
     }
 }
 
+#[derive(Debug)]
 enum BodyInner {
     Streaming(BodyStream),
     Fixed(Vec<u8>),

--- a/src/body.rs
+++ b/src/body.rs
@@ -132,7 +132,7 @@ impl<S: 'static> Extract<S> for MultipartForm {
     // Note: cannot use `existential type` here due to ICE
     type Fut = FutureObj<'static, Result<Self, Response>>;
 
-    fn extract(data: &mut S, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut S, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         // https://stackoverflow.com/questions/43424982/how-to-parse-multipart-forms-using-abonander-multipart-with-rocket
 
         const BOUNDARY: &str = "boundary=";
@@ -178,7 +178,7 @@ impl<T: Send + serde::de::DeserializeOwned + 'static, S: 'static> Extract<S> for
     // Note: cannot use `existential type` here due to ICE
     type Fut = FutureObj<'static, Result<Self, Response>>;
 
-    fn extract(data: &mut S, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut S, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         let mut body = std::mem::replace(req.body_mut(), Body::empty());
         FutureObj::new(Box::new(
             async move {
@@ -225,7 +225,7 @@ impl<T: Send + serde::de::DeserializeOwned + 'static, S: 'static> Extract<S> for
     // Note: cannot use `existential type` here due to ICE
     type Fut = FutureObj<'static, Result<Self, Response>>;
 
-    fn extract(data: &mut S, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut S, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         let mut body = std::mem::replace(req.body_mut(), Body::empty());
         FutureObj::new(Box::new(
             async move {
@@ -268,7 +268,7 @@ pub struct Str(pub String);
 impl<S: 'static> Extract<S> for Str {
     type Fut = FutureObj<'static, Result<Self, Response>>;
 
-    fn extract(data: &mut S, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut S, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         let mut body = std::mem::replace(req.body_mut(), Body::empty());
 
         FutureObj::new(Box::new(
@@ -299,7 +299,7 @@ pub struct StrLossy(pub String);
 impl<S: 'static> Extract<S> for StrLossy {
     type Fut = FutureObj<'static, Result<Self, Response>>;
 
-    fn extract(data: &mut S, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut S, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         let mut body = std::mem::replace(req.body_mut(), Body::empty());
 
         FutureObj::new(Box::new(
@@ -330,7 +330,7 @@ pub struct Bytes(pub Vec<u8>);
 impl<S: 'static> Extract<S> for Bytes {
     type Fut = FutureObj<'static, Result<Self, Response>>;
 
-    fn extract(data: &mut S, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut S, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         let mut body = std::mem::replace(req.body_mut(), Body::empty());
 
         FutureObj::new(Box::new(

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -11,5 +11,5 @@ pub trait Extract<Data>: Send + Sized + 'static {
     type Fut: Future<Output = Result<Self, Response>> + Send + 'static;
 
     /// Attempt to extract a value from the given request.
-    fn extract(data: &mut Data, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut;
+    fn extract(data: &mut Data, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut;
 }

--- a/src/head.rs
+++ b/src/head.rs
@@ -85,7 +85,7 @@ impl<T: Send + 'static + std::str::FromStr, S: 'static> Extract<S> for Path<T> {
                 Ok(t) => future::ok(Path(t)),
                 Err(_) => future::err(http::status::StatusCode::BAD_REQUEST.into_response()),
             },
-            None => future::err(http::status::StatusCode::BAD_REQUEST.into_response()),
+            None => future::err(http::status::StatusCode::INTERNAL_SERVER_ERROR.into_response()),
         }
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -27,7 +27,7 @@ where
 pub struct RequestContext<'a, Data> {
     pub app_data: Data,
     pub req: Request,
-    pub params: RouteMatch<'a>,
+    pub params: Option<RouteMatch<'a>>,
     pub(crate) endpoint: &'a BoxedEndpoint<Data>,
     pub(crate) next_middleware: &'a [Arc<dyn Middleware<Data> + Send + Sync>],
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -53,7 +53,7 @@ impl<T> DerefMut for Computed<T> {
 
 impl<Data: 'static, T: Compute> Extract<Data> for Computed<T> {
     type Fut = future::Ready<Result<Self, Response>>;
-    fn extract(data: &mut Data, req: &mut Request, params: &RouteMatch<'_>) -> Self::Fut {
+    fn extract(data: &mut Data, req: &mut Request, params: &Option<RouteMatch<'_>>) -> Self::Fut {
         future::ok(Computed(T::compute(req)))
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -353,11 +353,16 @@ mod tests {
         });
 
         for failing_path in &["/", "/a/a", "/a/b/a"] {
-            if block_on(simulate_request(&router, failing_path, &http::Method::GET)).is_some() {
-                panic!(
-                    "Routing of path `{}` should fail, but was successful",
-                    failing_path
-                );
+            if let Some(res) = block_on(simulate_request(&router, failing_path, &http::Method::GET))
+            {
+                if !res.status().is_client_error() {
+                    panic!(
+                        "Should have returned a client error when router cannot match with path {}",
+                        failing_path
+                    );
+                }
+            } else {
+                panic!("Should have received a response from {}", failing_path);
             };
         }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -150,8 +150,7 @@ impl<Data: Clone + Send + Sync + 'static> Router<Data> {
     ) -> RouteResult<'a, Data> {
         match self.table.route(path) {
             Some((route, route_match)) => route_match_success(route, route_match, method)
-                .or_else(|| Some(route_match_failure(default_handler, &self.middleware_base)))
-                .unwrap(),
+                .unwrap_or_else(|| route_match_failure(default_handler, &self.middleware_base)),
             None => route_match_failure(default_handler, &self.middleware_base),
         }
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -18,7 +18,7 @@ pub struct Router<Data> {
 
 pub(crate) struct RouteResult<'a, Data> {
     pub(crate) endpoint: &'a BoxedEndpoint<Data>,
-    pub(crate) params: RouteMatch<'a>,
+    pub(crate) params: Option<RouteMatch<'a>>,
     pub(crate) middleware: &'a [Arc<dyn Middleware<Data> + Send + Sync>],
 }
 
@@ -43,7 +43,7 @@ fn route_match_success<'a, Data>(
 
     Some(RouteResult {
         endpoint,
-        params: route_match,
+        params: Some(route_match),
         middleware,
     })
 }
@@ -52,11 +52,9 @@ fn route_match_failure<'a, Data>(
     endpoint: &'a BoxedEndpoint<Data>,
     middleware: &'a Vec<Arc<dyn Middleware<Data> + Send + Sync>>,
 ) -> RouteResult<'a, Data> {
-    let params = RouteMatch::empty();
-
     RouteResult {
         endpoint,
-        params,
+        params: None,
         middleware: &*middleware,
     }
 }


### PR DESCRIPTION
So this should tackle #10 .

Little bit of info on what is happening here,

The call to router will no longer return `Some(RouteResult)` and instead always returns a `RouteResult`. The router will fallback to the `default_handler` that is set. This allows us to use all middleware that are set in the `middleware_base` of the root router. In the example, you can try it and see that logging is now working for the fallback route.

I'm not going to lie, this particular PR was probably a bit above my Rust level and feels a bit hacky to me. Let me know what you guys think!

Also, special thank you to @tirr-c for his countless hours answering my non-stop questions ❤️ 

TODO:
I'd like to write some tests but I will wait until the final implementation to do so. Let's hold off on merging this at least until some tests are written 😄 