### PR TITLE
Pin a specific nightly version for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - nightly-2018-11-24
 
 before_script: |
   rustup component add rustfmt-preview clippy-preview


### PR DESCRIPTION
Todays nightly has a [bug that breaks the builds](https://travis-ci.org/hoodie/tide/builds/459748501). but it [seems to build](https://travis-ci.org/hoodie/tide/builds/459753610) with the version from November 24th