### PR TITLE
Expose Computed Values Api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ version = "0.3.0-alpha.9"
 
 [dev-dependencies]
 juniper = "0.10.0"
+cookie = "0.11.0"

--- a/examples/computed_values.rs
+++ b/examples/computed_values.rs
@@ -1,0 +1,43 @@
+#![feature(async_await, futures_api)]
+extern crate cookie;
+
+use cookie::Cookie;
+use tide::{Compute, Computed, Request};
+
+#[derive(Clone, Debug)]
+struct Cookies {
+    content: Option<CookieCream>,
+}
+
+#[derive(Clone, Debug)]
+struct CookieCream {
+    name: String,
+    value: String,
+}
+
+impl Compute for Cookies {
+    fn compute_fresh(req: &mut Request) -> Self {
+        let content = if let Some(raw_cookies) = req.headers().get("Cookie") {
+            let cookie = Cookie::parse(raw_cookies.to_str().unwrap()).unwrap();
+            Some(CookieCream {
+                name: cookie.name().into(),
+                value: cookie.value().into(),
+            })
+        } else {
+            None
+        };
+
+        Cookies { content }
+    }
+}
+
+async fn hello_cookies(cookies: Computed<Cookies>) -> String {
+    let Computed(cookies) = cookies;
+    format!("hello cookies: {:?}", cookies)
+}
+
+fn main() {
+    let mut app = tide::App::new(());
+    app.at("/").get(hello_cookies);
+    app.serve("127.0.0.1:7878")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
     endpoint::Endpoint,
     extract::Extract,
     middleware::Middleware,
-    request::Request,
+    request::{Compute, Computed, Request},
     response::{IntoResponse, Response},
     router::{Resource, Router},
 };

--- a/src/request.rs
+++ b/src/request.rs
@@ -36,7 +36,7 @@ struct ComputedMarker<T>(T);
 /// Endpoints can use this extractor to automatically compute values for a request, and re-use cached
 /// results if those values have been computed previously (e.g. in some middleware).
 #[derive(Clone)]
-pub struct Computed<T>(T);
+pub struct Computed<T>(pub T);
 
 impl<T> Deref for Computed<T> {
     type Target = T;


### PR DESCRIPTION
This adds an example for how to use computed values. We had to make the
Compute trait public for that.