### PR TITLE
Document routing syntax

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
     }
 
     /// Add a new resource at `path`.
+    /// See [Router.at](struct.Router.html#method.at) for details.
     pub fn at<'a>(&'a mut self, path: &'a str) -> Resource<'a, Data> {
         self.router.at(path)
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -27,18 +27,24 @@ impl<Data: Clone + Send + Sync + 'static> Router<Data> {
     /// Routing means mapping an HTTP request to an endpoint. Here Tide applies a "table of
     /// contents" approach, which makes it easy to see the overall app structure. Endpoints are
     /// selected solely by the path and HTTP method of a request: the path determines the resource
-    /// and the HTTP verb the endpoint of the selected resource. Example:
+    /// and the HTTP verb the respective endpoint of the selected resource. Example:
     ///
     /// ```rust,no_run
+    /// # #![feature(async_await)]
     /// # let mut app = tide::App::new(());
     /// app.at("/").get(async || "Hello, world!");
     /// ```
     ///
-    /// A path is comprised of zero or many segments, i.e. non-empty strings separated by '/'. Each
-    /// segment is either a concrete segment or a wildcard segment, the latter defined either by
-    /// "{}" or by "{name}" for a so called named wildcard segment. A wildcard segment is used to
-    /// extract the value of the respective segment in order to pass it along to the endpoint as an
-    /// argument. Here are some examples omitting the HTTP verb based endpoint selection:
+    /// A path is comprised of zero or many segments, i.e. non-empty strings separated by '/'. There
+    /// are two kinds of segments: concrete and wildcard. A concrete segment is used to exactly
+    /// match the respective part of the path of the incoming request. A wildcard segment on the
+    /// other hand extracts and parses the respective part of the path of the incoming request to
+    /// pass it along to the endpoint as an argument. A wildcard segment is either defined by "{}"
+    /// or by "{name}" for a so called named wildcard segment which must have an implementation of
+    /// `NamedComponent`. It is not possible to define wildcard segments with different names for
+    /// otherwise identical paths.
+    ///
+    /// Here are some examples omitting the HTTP verb based endpoint selection:
     ///
     /// ```rust,no_run
     /// # let mut app = tide::App::new(());
@@ -48,10 +54,8 @@ impl<Data: Clone + Send + Sync + 'static> Router<Data> {
     /// app.at("add_two/{num}");
     /// ```
     ///
-    /// Notice that resources must be unique – adding the same resource twice results in a panic on
-    /// startup. Further on it is also noteworthy that there is no fallback route matching, i.e.
-    /// either a resource is a full match or not, which means that the order of adding resources has
-    /// no effect.
+    /// Notice that there is no fallback route matching, i.e. either a resource is a full match or
+    /// not, which means that the order of adding resources has no effect.
     pub fn at<'a>(&'a mut self, path: &'a str) -> Resource<'a, Data> {
         let table = self.table.setup_table(path);
         Resource {


### PR DESCRIPTION
I took a first stab at #18.

Some items for discussion:
- I suggest we consistently use one of the terms "component" or "segment" for the "/"-separated parts of a URL path; currently both are used in `lib.rs` and other places; Akka HTTP uses "segment" which I also prefer
- ~The doc fist test (around line 33) fails: "help: add #![feature(async_await)] to the crate attributes to enable"; but these are enabled, what to do?~
- How can I refer from one `at` method (in "app.rs") to another one (in "router.rs")? Is the way I did it correct?
