### PR TITLE
Implemented Deref for body types and some Path types, updated examples

### DIFF
--- a/examples/body_types.rs
+++ b/examples/body_types.rs
@@ -11,29 +11,29 @@ struct Message {
 }
 
 async fn echo_string(msg: body::Str) -> String {
-    println!("String: {}", msg.0);
-    format!("{}", msg.0)
+    println!("String: {}", *msg);
+    format!("{}", *msg)
 }
 
 async fn echo_string_lossy(msg: body::StrLossy) -> String {
-    println!("String: {}", msg.0);
-    format!("{}", msg.0)
+    println!("String: {}", *msg);
+    format!("{}", *msg)
 }
 
 async fn echo_vec(msg: body::Bytes) -> String {
-    println!("Vec<u8>: {:?}", msg.0);
+    println!("Vec<u8>: {:?}", *msg);
 
-    String::from_utf8(msg.0).unwrap()
+    String::from_utf8(msg.to_vec()).unwrap()
 }
 
 async fn echo_json(msg: body::Json<Message>) -> body::Json<Message> {
-    println!("JSON: {:?}", msg.0);
+    println!("JSON: {:?}", *msg);
 
     msg
 }
 
 async fn echo_form(msg: body::Form<Message>) -> body::Form<Message> {
-    println!("Form: {:?}", msg.0);
+    println!("Form: {:?}", *msg);
 
     msg
 }

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -49,8 +49,7 @@ async fn handle_graphql(
     ctx: AppData<Context>,
     query: body::Json<juniper::http::GraphQLRequest>,
 ) -> Result<Response, StatusCode> {
-    let request = query.0;
-    let response = request.execute(&Schema::new(Query, Mutation), &ctx);
+    let response = query.execute(&Schema::new(Query, Mutation), &ctx);
 
     // `response` has the lifetime of `request`, so we can't use `IntoResponse` directly.
     let body_vec = serde_json::to_vec(&response).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;

--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -48,7 +48,7 @@ impl Database {
 }
 
 async fn new_message(mut db: AppData<Database>, msg: body::Json<Message>) -> String {
-    db.insert(msg.0).to_string()
+    db.insert(msg.clone()).to_string()
 }
 
 async fn set_message(
@@ -56,7 +56,7 @@ async fn set_message(
     id: head::Path<usize>,
     msg: body::Json<Message>,
 ) -> Result<(), StatusCode> {
-    if db.set(id.0, msg.0) {
+    if db.set(*id, msg.clone()) {
         Ok(())
     } else {
         Err(StatusCode::NOT_FOUND)
@@ -67,7 +67,7 @@ async fn get_message(
     mut db: AppData<Database>,
     id: head::Path<usize>,
 ) -> Result<body::Json<Message>, StatusCode> {
-    if let Some(msg) = db.get(id.0) {
+    if let Some(msg) = db.get(*id) {
         Ok(body::Json(msg))
     } else {
         Err(StatusCode::NOT_FOUND)

--- a/examples/multipart-form/main.rs
+++ b/examples/multipart-form/main.rs
@@ -15,7 +15,7 @@ struct Message {
 }
 
 async fn upload_file(
-    multipart_form: body::MultipartForm,
+    mut multipart_form: body::MultipartForm,
 ) -> Result<body::Json<Message>, StatusCode> {
     // https://stackoverflow.com/questions/43424982/how-to-parse-multipart-forms-using-abonander-multipart-with-rocket
     let mut message = Message {
@@ -24,8 +24,7 @@ async fn upload_file(
         file: None,
     };
 
-    let mut multipart = multipart_form.0;
-    multipart
+    multipart_form
         .foreach_entry(|mut entry| match entry.headers.name.as_str() {
             "file" => {
                 let mut vec = Vec::new();

--- a/src/body.rs
+++ b/src/body.rs
@@ -206,6 +206,12 @@ impl<T> Deref for Json<T> {
     }
 }
 
+impl<T> DerefMut for Json<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
 /// A wrapper for form encoded (application/x-www-form-urlencoded) (de)serialization of bodies.
 ///
 /// This type is usable both as an extractor (argument to an endpoint) and as a response
@@ -249,6 +255,12 @@ impl<T> Deref for Form<T> {
     }
 }
 
+impl<T> DerefMut for Form<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
 pub struct Str(pub String);
 
 impl<S: 'static> Extract<S> for Str {
@@ -271,6 +283,12 @@ impl Deref for Str {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
+    }
+}
+
+impl DerefMut for Str {
+    fn deref_mut(&mut self) -> &mut String {
+        &mut self.0
     }
 }
 
@@ -299,6 +317,12 @@ impl Deref for StrLossy {
     }
 }
 
+impl DerefMut for StrLossy {
+    fn deref_mut(&mut self) -> &mut String {
+        &mut self.0
+    }
+}
+
 pub struct Bytes(pub Vec<u8>);
 
 impl<S: 'static> Extract<S> for Bytes {
@@ -320,5 +344,11 @@ impl Deref for Bytes {
     type Target = Vec<u8>;
     fn deref(&self) -> &Vec<u8> {
         &self.0
+    }
+}
+
+impl DerefMut for Bytes {
+    fn deref_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.0
     }
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -8,6 +8,7 @@ use http::status::StatusCode;
 use multipart::server::Multipart;
 use pin_utils::pin_mut;
 use std::io::Cursor;
+use std::ops::{Deref, DerefMut};
 
 use crate::{Extract, IntoResponse, Request, Response, RouteMatch};
 
@@ -152,6 +153,19 @@ impl<S: 'static> Extract<S> for MultipartForm {
     }
 }
 
+impl Deref for MultipartForm {
+    type Target = Multipart<Cursor<Vec<u8>>>;
+    fn deref(&self) -> &Multipart<Cursor<Vec<u8>>> {
+        &self.0
+    }
+}
+
+impl DerefMut for MultipartForm {
+    fn deref_mut(&mut self) -> &mut Multipart<Cursor<Vec<u8>>> {
+        &mut self.0
+    }
+}
+
 /// A wrapper for json (de)serialization of bodies.
 ///
 /// This type is usable both as an extractor (argument to an endpoint) and as a response
@@ -182,6 +196,13 @@ impl<T: 'static + Send + serde::Serialize> IntoResponse for Json<T> {
             .header("Content-Type", "application/json")
             .body(Body::from(serde_json::to_vec(&self.0).unwrap()))
             .unwrap()
+    }
+}
+
+impl<T> Deref for Json<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
     }
 }
 
@@ -221,6 +242,13 @@ impl<T: 'static + Send + serde::Serialize> IntoResponse for Form<T> {
     }
 }
 
+impl<T> Deref for Form<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
 pub struct Str(pub String);
 
 impl<S: 'static> Extract<S> for Str {
@@ -236,6 +264,13 @@ impl<S: 'static> Extract<S> for Str {
                 Ok(Str(string))
             },
         ))
+    }
+}
+
+impl Deref for Str {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
     }
 }
 
@@ -257,6 +292,13 @@ impl<S: 'static> Extract<S> for StrLossy {
     }
 }
 
+impl Deref for StrLossy {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+
 pub struct Bytes(pub Vec<u8>);
 
 impl<S: 'static> Extract<S> for Bytes {
@@ -271,5 +313,12 @@ impl<S: 'static> Extract<S> for Bytes {
                 Ok(Bytes(body))
             },
         ))
+    }
+}
+
+impl Deref for Bytes {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Vec<u8> {
+        &self.0
     }
 }

--- a/src/head.rs
+++ b/src/head.rs
@@ -4,7 +4,7 @@
 //! automatically parse out information from a request.
 
 use futures::future;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use crate::{Extract, IntoResponse, Request, Response, RouteMatch};
@@ -66,6 +66,12 @@ impl<T> Deref for Path<T> {
     }
 }
 
+impl<T> DerefMut for Path<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
 /// A key for storing the current component match in a request's `extensions`
 struct PathIdx(usize);
 
@@ -98,6 +104,12 @@ impl<T: NamedComponent> Deref for Named<T> {
     type Target = T;
     fn deref(&self) -> &T {
         &self.0
+    }
+}
+
+impl<T: NamedComponent> DerefMut for Named<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
     }
 }
 

--- a/src/head.rs
+++ b/src/head.rs
@@ -4,6 +4,7 @@
 //! automatically parse out information from a request.
 
 use futures::future;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::{Extract, IntoResponse, Request, Response, RouteMatch};
@@ -58,6 +59,13 @@ impl Head {
 /// as type `T`, failing with a `NOT_FOUND` response if the component fails to parse.
 pub struct Path<T>(pub T);
 
+impl<T> Deref for Path<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
 /// A key for storing the current component match in a request's `extensions`
 struct PathIdx(usize);
 
@@ -85,6 +93,13 @@ pub trait NamedComponent: Send + 'static + std::str::FromStr {
 /// FromStr trait. Fails with a `BAD_REQUEST` response if the component is not found, fails to
 /// parse or if multiple identically named components exist.
 pub struct Named<T: NamedComponent>(pub T);
+
+impl<T: NamedComponent> Deref for Named<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
 
 impl<T: NamedComponent, S: 'static> Extract<S> for Named<T> {
     type Fut = future::Ready<Result<Self, Response>>;


### PR DESCRIPTION
The following body types are covered:
- Str
- StrLossy
- Bytes
- Form
- MuliypartForm
- Json
And some types from head.rs:
- Path
- Named
Are all the cases covered? I'm actually not sure about Named, too.