### PR TITLE
Rename path component to path segment

### DIFF
--- a/examples/named_path.rs
+++ b/examples/named_path.rs
@@ -1,10 +1,10 @@
 #![feature(async_await, futures_api)]
 
-use tide::head::{Named, NamedComponent};
+use tide::head::{Named, NamedSegment};
 
 struct Number(i32);
 
-impl NamedComponent for Number {
+impl NamedSegment for Number {
     const NAME: &'static str = "num";
 }
 

--- a/examples/simple_nested_router.rs
+++ b/examples/simple_nested_router.rs
@@ -3,13 +3,13 @@
 #![feature(async_await, futures_api)]
 
 use tide::{
-    head::{Named, NamedComponent},
+    head::{Named, NamedSegment},
     Router,
 };
 
 struct Number(i32);
 
-impl NamedComponent for Number {
+impl NamedSegment for Number {
     const NAME: &'static str = "num";
 }
 

--- a/path_table/src/lib.rs
+++ b/path_table/src/lib.rs
@@ -23,7 +23,7 @@ struct Wildcard<R> {
     table: PathTable<R>,
 }
 
-/// For a successful match, this structure says how any wildcard components were matched.
+/// For a successful match, this structure says how any wildcard segments were matched.
 #[derive(Debug)]
 pub struct RouteMatch<'a> {
     /// Wildcard matches in the order they appeared in the path.

--- a/src/router.rs
+++ b/src/router.rs
@@ -74,7 +74,7 @@ impl<Data: Clone + Send + Sync + 'static> Router<Data> {
     /// other hand extracts and parses the respective part of the path of the incoming request to
     /// pass it along to the endpoint as an argument. A wildcard segment is either defined by "{}"
     /// or by "{name}" for a so called named wildcard segment which must have an implementation of
-    /// `NamedComponent`. It is not possible to define wildcard segments with different names for
+    /// `NamedSegment`. It is not possible to define wildcard segments with different names for
     /// otherwise identical paths.
     ///
     /// Here are some examples omitting the HTTP verb based endpoint selection:


### PR DESCRIPTION
I know that naming is hard, but I nevertheless give it a try: Like asked in #76 I suggest to consistently use either of the terms "component" or "segment" for the "/"-separated parts of the path of a URL. Currently both terms are mixed in lib.rs and other places. I suggest to use "segment" which I think is more specific in the context of a path than "component".