### PR TITLE
Enable only needed features for `multipart`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,14 @@ serde_derive = "1.0.80"
 serde_json = "1.0.32"
 typemap = "0.3.3"
 serde_qs = "0.4.1"
-multipart = "0.15.3"
 slog = "2.4.1"
 slog-term = "2.4.0"
 slog-async = "2.3.0"
+
+[dependencies.multipart]
+version = "0.15.3"
+default-features = false
+features = ["server"]
 
 [dependencies.path_table]
 path = "path_table"


### PR DESCRIPTION
By default, `multipart` will be built with a bunch of default features that Tide doesn't really use. This PR turns off any unused features in order to boost the initial build time.