### PR TITLE
Update futures-preview and pin-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["path_table"]
 [dependencies]
 http = "0.1"
 hyper = "0.12.0"
-pin-utils = "0.1.0-alpha.3"
+pin-utils = "0.1.0-alpha.4"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = "1.0.32"
@@ -38,7 +38,7 @@ path = "path_table"
 
 [dependencies.futures-preview]
 features = ["compat"]
-version = "0.3.0-alpha.10"
+version = "0.3.0-alpha.11"
 
 [dev-dependencies]
 juniper = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
     futures_api,
     async_await,
     await_macro,
-    pin,
-    arbitrary_self_types,
     existential_type
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,7 @@
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![cfg_attr(test, deny(warnings))]
 #![allow(unused_variables)]
-#![feature(
-    futures_api,
-    async_await,
-    await_macro,
-    existential_type
-)]
+#![feature(futures_api, async_await, await_macro, existential_type)]
 
 //!
 //! Welcome to Tide.


### PR DESCRIPTION
## Description
Update `futures-preview` and `pin-utils` to match new `Pin` APIs.

## Motivation and Context
Previously, build was failing on the latest nightly due to the change of API.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
