### PR TITLE
Add status code modifier for IntoResponse

### DIFF
--- a/examples/default_handler.rs
+++ b/examples/default_handler.rs
@@ -1,19 +1,13 @@
 #![feature(async_await)]
 
 use http::status::StatusCode;
-use tide::body;
+use tide::IntoResponse;
 
 fn main() {
     let mut app = tide::App::new(());
     app.at("/").get(async || "Hello, world!");
 
-    app.default_handler(async || {
-        http::Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .header("Content-Type", "text/plain")
-            .body(body::Body::from("¯\\_(ツ)_/¯".to_string().into_bytes()))
-            .unwrap()
-    });
+    app.default_handler(async || "¯\\_(ツ)_/¯".with_status(StatusCode::NOT_FOUND));
 
     let address = "127.0.0.1:8000".to_owned();
     println!("Server is listening on http://{}", address);

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,7 +8,22 @@ pub type Response = http::Response<Body>;
 
 /// A value that is synchronously convertable into a `Response`.
 pub trait IntoResponse: Send + 'static + Sized {
+    /// Convert the value into a `Response`.
     fn into_response(self) -> Response;
+
+    /// Create a new `IntoResponse` value that will respond with the given status code.
+    ///
+    /// ```
+    /// # use tide::IntoResponse;
+    /// let resp = "Hello, 404!".with_status(http::status::StatusCode::NOT_FOUND).into_response();
+    /// assert_eq!(resp.status(), http::status::StatusCode::NOT_FOUND);
+    /// ```
+    fn with_status(self, status: http::status::StatusCode) -> WithStatus<Self> {
+        WithStatus {
+            inner: self,
+            status,
+        }
+    }
 }
 
 impl IntoResponse for () {
@@ -78,5 +93,30 @@ impl<T: IntoResponse, U: IntoResponse> IntoResponse for Result<T, U> {
 impl<T: Send + 'static + Into<Body>> IntoResponse for http::Response<T> {
     fn into_response(self) -> Response {
         self.map(Into::into)
+    }
+}
+
+/// A response type that modifies the status code.
+pub struct WithStatus<R> {
+    inner: R,
+    status: http::status::StatusCode,
+}
+
+impl<R: IntoResponse> IntoResponse for WithStatus<R> {
+    fn into_response(self) -> Response {
+        let mut resp = self.inner.into_response();
+        *resp.status_mut() = self.status;
+        resp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status() {
+        let resp = "foo".with_status(http::status::StatusCode::NOT_FOUND).into_response();
+        assert_eq!(resp.status(), http::status::StatusCode::NOT_FOUND);
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -116,7 +116,9 @@ mod tests {
 
     #[test]
     fn test_status() {
-        let resp = "foo".with_status(http::status::StatusCode::NOT_FOUND).into_response();
+        let resp = "foo"
+            .with_status(http::status::StatusCode::NOT_FOUND)
+            .into_response();
         assert_eq!(resp.status(), http::status::StatusCode::NOT_FOUND);
     }
 }


### PR DESCRIPTION
## Description
This PR adds a provided method, `with_status`, to `IntoResponse`. This method returns a wrapper around the value that modifies response status code.

## Motivation and Context
Part of #116. This change makes returning `Json` error easier.

I'm not sure if this is the right direction, though.

## How Has This Been Tested?
I've added a unit test that runs `with_status` on `&'static str`, then compares the final status code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
