### PR TITLE
Relieve lifetime bound of IntoResponse

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -270,7 +270,7 @@ impl<T: Send + serde::de::DeserializeOwned + 'static, S: 'static> Extract<S> for
     }
 }
 
-impl<T: 'static + Send + serde::Serialize> IntoResponse for Json<T> {
+impl<T: Send + serde::Serialize> IntoResponse for Json<T> {
     fn into_response(self) -> Response {
         // TODO: think about how to handle errors
         http::Response::builder()

--- a/src/response.rs
+++ b/src/response.rs
@@ -7,7 +7,7 @@ use crate::body::Body;
 pub type Response = http::Response<Body>;
 
 /// A value that is synchronously convertable into a `Response`.
-pub trait IntoResponse: Send + 'static + Sized {
+pub trait IntoResponse: Send + Sized {
     /// Convert the value into a `Response`.
     fn into_response(self) -> Response;
 
@@ -57,7 +57,7 @@ impl IntoResponse for String {
     }
 }
 
-impl IntoResponse for &'static str {
+impl IntoResponse for &'_ str {
     fn into_response(self) -> Response {
         self.to_string().into_response()
     }
@@ -90,7 +90,7 @@ impl<T: IntoResponse, U: IntoResponse> IntoResponse for Result<T, U> {
     }
 }
 
-impl<T: Send + 'static + Into<Body>> IntoResponse for http::Response<T> {
+impl<T: Send + Into<Body>> IntoResponse for http::Response<T> {
     fn into_response(self) -> Response {
         self.map(Into::into)
     }


### PR DESCRIPTION
## Description
Remove `'static` bound from `IntoResponse`.

## Motivation and Context
We don't need to *require* `IntoResponse` to be `'static`. Even if the value is not `'static`, most of the time we'll going to build a response in the same way as `'static` ones. If it doesn't work for some type, we can add `'static` bound to the `impl` block.

## How Has This Been Tested?
All existing tests passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
