### PR TITLE
Clean up doctests and messages example via Default trait

### DIFF
--- a/examples/messages.rs
+++ b/examples/messages.rs
@@ -7,7 +7,7 @@ use http::status::StatusCode;
 use std::sync::{Arc, Mutex};
 use tide::{body, head, App, AppData};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct Database {
     contents: Arc<Mutex<Vec<Message>>>,
 }
@@ -19,12 +19,6 @@ struct Message {
 }
 
 impl Database {
-    fn new() -> Database {
-        Database {
-            contents: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
     fn insert(&mut self, msg: Message) -> usize {
         let mut table = self.contents.lock().unwrap();
         table.push(msg);
@@ -75,7 +69,7 @@ async fn get_message(
 }
 
 fn main() {
-    let mut app = App::new(Database::new());
+    let mut app = App::new(Database::default());
 
     app.at("/message").post(new_message);
     app.at("/message/{}").get(get_message);

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,17 +53,9 @@ use crate::{
 /// use tide::AppData;
 /// use tide::body;
 ///
-/// #[derive(Clone)]
+/// #[derive(Clone, Default)]
 /// struct Database {
 ///     contents: Arc<Mutex<Vec<String>>>,
-/// }
-///
-/// impl Database {
-///     fn new() -> Database {
-///         Database {
-///             contents: Arc::new(Mutex::new(Vec::new())),
-///         }
-///     }
 /// }
 ///
 /// async fn insert(
@@ -75,7 +67,7 @@ use crate::{
 /// }
 ///
 /// fn main() {
-///     let mut app = tide::App::new(Database::new());
+///     let mut app = tide::App::new(Database::default());
 ///     app.at("/messages/insert").post(insert);
 ///     app.serve()
 /// }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -40,17 +40,9 @@ use crate::{
 /// use tide::AppData;
 /// use tide::body;
 ///
-/// #[derive(Clone)]
+/// #[derive(Clone, Default)]
 /// struct Database {
 ///     contents: Arc<Mutex<Vec<String>>>,
-/// }
-///
-/// impl Database {
-///     fn new() -> Database {
-///         Database {
-///             contents: Arc::new(Mutex::new(Vec::new())),
-///         }
-///     }
 /// }
 ///
 /// async fn insert(
@@ -62,7 +54,7 @@ use crate::{
 /// }
 ///
 /// fn main() {
-///     let mut app = tide::App::new(Database::new());
+///     let mut app = tide::App::new(Database::default());
 ///     app.at("/messages/insert").post(insert);
 ///     app.serve()
 /// }


### PR DESCRIPTION
I've noticed that some doctests and one example have a pattern where a `fn new()` is defined for `Database` that basically does nothing except call `::new()` on all members. This is essentially the same as what the `Default` trait does, so this PR proposes to use that instead in the interest of having shorter and more idiomatic examples.

## Description
This PR changes two doctests (one in `app.rs` and one in `endpoint.rs`) as well as the example `messages.rs` to derive and use `Default::default()` for making a new empty Database instead of defining a `fn new()` in an inherent impl block and using that.

## Motivation and Context
This PR is not strictly required, since it doesn't fix any technical problems.
It only serves to make the doctests and examples a little more concise,
allowing potential readers to focus on the parts that are specific to tide and more interesting.

## How Has This Been Tested?
Since this PR doesn't change any functionality in tide itself, I only did the following:
- ran `cargo +nightly test --all` (on the nightly from 2019-01-12)
- ran the "messages" example and tried posting, changing and getting a message via curl.

Everything worked as expected.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation. -> My change *is* a change to the documentation.
- [ ] I have updated the documentation accordingly. -> see above.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes. -> This PR doesn't touch the codebase itself, only doctests.
- [x] All new and existing tests passed.
