### PR TITLE
Fix links to `Code of Conduct`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Repository.
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
 
 ## Code of Conduct
-The project has a [Code of Conduct][./CODE_OF_CONDUCT.md] that *all*
+The project has a [Code of Conduct](./CODE_OF_CONDUCT.md) that *all*
 contributors are expected to follow. This code describes the *minimum* behavior
 expectations for all contributors.
 
@@ -25,7 +25,7 @@ intended, above all else, to help establish a culture within the project that
 allows anyone and everyone who wants to contribute to feel safe doing so.
 
 Should any individual act in any way that is considered in violation of the
-[Code of Conduct][./CODE_OF_CONDUCT.md], corrective actions will be taken. It is
+[Code of Conduct](./CODE_OF_CONDUCT.md), corrective actions will be taken. It is
 possible, however, for any individual to *act* in such a manner that is not in
 violation of the strict letter of the Code of Conduct guidelines while still
 going completely against the spirit of what that Code is intended to accomplish.
@@ -37,7 +37,7 @@ goal.
 
 ## Bad Actors
 All contributors to tacitly agree to abide by both the letter and
-spirit of the [Code of Conduct][./CODE_OF_CONDUCT.md]. Failure, or
+spirit of the [Code of Conduct](./CODE_OF_CONDUCT.md). Failure, or
 unwillingness, to do so will result in contributions being respectfully
 declined.
 


### PR DESCRIPTION
## Description
Some links in the contribution documentation were broken due to switched up style of brackets (`[]` instead of `()`)

## Motivation and Context
Fixes #127 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
