### PR TITLE
make the Environment struct public

### DIFF
--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -10,7 +10,7 @@ use crate::{Extract, Request, Response, RouteMatch};
 
 mod default_config;
 
-pub use self::default_config::{Configuration, ConfigurationBuilder};
+pub use self::default_config::{Configuration, ConfigurationBuilder, Environment};
 
 trait StoreItem: Any + Send + Sync {
     fn clone_any(&self) -> Box<dyn StoreItem>;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Makes the Environment struct publicly available.

## Motivation and Context

I noticed the Environment struct is required in some APIs, but wasn't publicly available.

## How Has This Been Tested?
Works locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
