### PR TITLE
Refactor to use HttpService internally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - nightly
 
 before_script: |
-  rustup install nightly-2019-01-25
+  rustup install nightly-2019-02-21
   rustup component add rustfmt-preview clippy-preview
 script: |
   cargo fmt --all -- --check &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.0.4"
 [dependencies]
 cookie = "0.11"
 http = "0.1"
-http-service = "0.1.2"
+http-service = "0.1.4"
 hyper = "0.12.24"
 path-table = "1.0.0"
 pin-utils = "0.1.0-alpha.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ version = "0.0.4"
 [dependencies]
 cookie = "0.11"
 http = "0.1"
-http-service = "0.1.1"
-hyper = "0.12.0"
+http-service = "0.1.2"
+hyper = "0.12.24"
 path-table = "1.0.0"
 pin-utils = "0.1.0-alpha.4"
 serde = "1.0.80"
@@ -30,7 +30,7 @@ typemap = "0.3.3"
 
 [dependencies.futures-preview]
 features = ["compat"]
-version = "0.3.0-alpha.12"
+version = "0.3.0-alpha.13"
 
 [dependencies.multipart]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,28 +13,29 @@ repository = "https://github.com/rust-net-web/tide"
 version = "0.0.4"
 
 [dependencies]
+cookie = "0.11"
 http = "0.1"
+http-service = "0.1.1"
 hyper = "0.12.0"
+path-table = "1.0.0"
 pin-utils = "0.1.0-alpha.4"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = "1.0.32"
-typemap = "0.3.3"
 serde_qs = "0.4.1"
 slog = "2.4.1"
-slog-term = "2.4.0"
 slog-async = "2.3.0"
-cookie="0.11"
-path-table = "1.0.0"
-
-[dependencies.multipart]
-version = "0.15.3"
-default-features = false
-features = ["server"]
+slog-term = "2.4.0"
+typemap = "0.3.3"
 
 [dependencies.futures-preview]
 features = ["compat"]
 version = "0.3.0-alpha.12"
+
+[dependencies.multipart]
+default-features = false
+features = ["server"]
+version = "0.15.3"
 
 [dev-dependencies]
 basic-cookies = "0.1.3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -176,7 +176,8 @@ struct Server<Data> {
 }
 
 impl<Data> HttpService for Server<Data>
-    where Data: Clone + Send + Sync + 'static
+where
+    Data: Clone + Send + Sync + 'static,
 {
     type Connection = ();
     type ConnectionFuture = future::Ready<Result<(), std::io::Error>>;
@@ -209,7 +210,7 @@ impl<Data> HttpService for Server<Data>
                     next_middleware: middleware,
                 };
                 Ok(await!(ctx.next()))
-            }
+            },
         ))
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,5 @@
-use futures::{
-    compat::{Compat, Future01CompatExt, Compat01As03},
-    future::{self, FutureObj},
-    prelude::*,
-};
-use http_service::Body;
-use hyper::service::Service;
+use futures::future::{self, FutureObj};
+use http_service::HttpService;
 use std::{
     any::Any,
     fmt::Debug,
@@ -169,21 +164,7 @@ impl<Data: Clone + Send + Sync + 'static> App<Data> {
 
         println!("Server is listening on: http://{}", addr);
 
-        let server: Server<Data> = self.into_server();
-
-        // TODO: be more robust
-        let server = hyper::Server::bind(&addr)
-            .serve(move || {
-                let res: Result<_, std::io::Error> = Ok(server.clone());
-                res
-            })
-            .compat()
-            .map(|_| {
-                let res: Result<(), ()> = Ok(());
-                res
-            })
-            .compat();
-        hyper::rt::run(server);
+        crate::serve::serve(self.into_server(), addr);
     }
 }
 
@@ -194,24 +175,21 @@ struct Server<Data> {
     default_handler: Arc<EndpointData<Data>>,
 }
 
-impl<Data: Clone + Send + Sync + 'static> Service for Server<Data> {
-    type ReqBody = hyper::Body;
-    type ResBody = hyper::Body;
-    type Error = std::io::Error;
-    type Future = Compat<FutureObj<'static, Result<http::Response<hyper::Body>, Self::Error>>>;
+impl<Data> HttpService for Server<Data>
+    where Data: Clone + Send + Sync + 'static
+{
+    type Connection = ();
+    type ConnectionFuture = future::Ready<Result<(), std::io::Error>>;
+    type Fut = FutureObj<'static, Result<http_service::Response, std::io::Error>>;
 
-    fn call(&mut self, req: http::Request<hyper::Body>) -> Self::Future {
+    fn connect(&self) -> Self::ConnectionFuture {
+        future::ok(())
+    }
+
+    fn respond(&self, _conn: &mut (), req: http_service::Request) -> Self::Fut {
         let data = self.data.clone();
         let router = self.router.clone();
         let default_handler = self.default_handler.clone();
-
-        let req = req.map(|hyper_body| {
-            let stream = Compat01As03::new(hyper_body).map(|c| match c {
-                Ok(chunk) => Ok(chunk.into_bytes()),
-                Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
-            });
-            Body::from_stream(stream)
-        });
         let path = req.uri().path().to_owned();
         let method = req.method().to_owned();
 
@@ -230,14 +208,9 @@ impl<Data: Clone + Send + Sync + 'static> Service for Server<Data> {
                     endpoint,
                     next_middleware: middleware,
                 };
-                let res = await!(ctx.next());
-
-                Ok(res.map(|body| {
-                    hyper::Body::wrap_stream(body.compat())
-                }))
-            },
+                Ok(await!(ctx.next()))
+            }
         ))
-        .compat()
     }
 }
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -83,7 +83,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::{configuration::Store, Extract, IntoResponse, Request, Response, RouteMatch};
 
-async fn body_to_vec(body: Body) -> Result<Vec<u8>, io::Error> {
+pub(crate) async fn body_to_vec(body: Body) -> Result<Vec<u8>, io::Error> {
     let mut bytes = Vec::new();
     pin_mut!(body);
     while let Some(chunk) = await!(body.next()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod middleware;
 mod request;
 mod response;
 mod router;
+mod serve;
 
 pub use crate::{
     app::{App, AppData},

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,8 @@
 use futures::future;
+use http_service::Body;
 use std::ops::{Deref, DerefMut};
 
-use crate::{body::Body, configuration::Store, Extract, Response, RouteMatch};
+use crate::{configuration::Store, Extract, Response, RouteMatch};
 
 /// An HTTP request.
 ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,6 @@
+use http_service::Body;
+
 use crate::body;
-use crate::body::Body;
 
 /// An HTTP response.
 ///

--- a/src/router.rs
+++ b/src/router.rs
@@ -392,8 +392,7 @@ mod tests {
                 } else {
                     panic!("Routing of path `{}` failed", path);
                 };
-            let body =
-                block_on(res.into_body().into_vec()).expect("Reading body should succeed");
+            let body = block_on(res.into_body().into_vec()).expect("Reading body should succeed");
             assert_eq!(&*body, path.as_bytes());
         }
     }
@@ -443,8 +442,7 @@ mod tests {
                 } else {
                     panic!("Routing of path `{}` failed", path);
                 };
-            let body =
-                block_on(res.into_body().into_vec()).expect("Reading body should succeed");
+            let body = block_on(res.into_body().into_vec()).expect("Reading body should succeed");
             assert_eq!(&*body, path.as_bytes());
         }
     }
@@ -463,8 +461,7 @@ mod tests {
             } else {
                 panic!("Routing of {} `{}` failed", method, path);
             };
-            let body =
-                block_on(res.into_body().into_vec()).expect("Reading body should succeed");
+            let body = block_on(res.into_body().into_vec()).expect("Reading body should succeed");
             assert_eq!(&*body, format!("{} {}", path, method).as_bytes());
         }
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -325,7 +325,7 @@ mod tests {
     use futures::{executor::block_on, future::FutureObj};
 
     use super::*;
-    use crate::{body::Body, middleware::RequestContext, AppData, Response};
+    use crate::{middleware::RequestContext, AppData, Response, body::body_to_vec};
 
     fn passthrough_middleware<Data: Clone + Send>(
         ctx: RequestContext<Data>,
@@ -351,7 +351,7 @@ mod tests {
         let data = Data::default();
         let req = http::Request::builder()
             .method(method)
-            .body(Body::empty())
+            .body(http_service::Body::empty())
             .unwrap();
 
         let ctx = RequestContext {
@@ -393,7 +393,7 @@ mod tests {
                     panic!("Routing of path `{}` failed", path);
                 };
             let body =
-                block_on(res.into_body().read_to_vec()).expect("Reading body should succeed");
+                block_on(body_to_vec(res.into_body())).expect("Reading body should succeed");
             assert_eq!(&*body, path.as_bytes());
         }
     }
@@ -444,7 +444,7 @@ mod tests {
                     panic!("Routing of path `{}` failed", path);
                 };
             let body =
-                block_on(res.into_body().read_to_vec()).expect("Reading body should succeed");
+                block_on(body_to_vec(res.into_body())).expect("Reading body should succeed");
             assert_eq!(&*body, path.as_bytes());
         }
     }
@@ -464,7 +464,7 @@ mod tests {
                 panic!("Routing of {} `{}` failed", method, path);
             };
             let body =
-                block_on(res.into_body().read_to_vec()).expect("Reading body should succeed");
+                block_on(body_to_vec(res.into_body())).expect("Reading body should succeed");
             assert_eq!(&*body, format!("{} {}", path, method).as_bytes());
         }
     }
@@ -570,11 +570,11 @@ mod tests {
         router.apply_default_config(); // simulating App behavior
 
         let res = block_on(simulate_request(&router, "/", &http::Method::GET)).unwrap();
-        let body = block_on(res.into_body().read_to_vec()).unwrap();
+        let body = block_on(body_to_vec(res.into_body())).unwrap();
         assert_eq!(&*body, &*b"foo");
 
         let res = block_on(simulate_request(&router, "/bar", &http::Method::GET)).unwrap();
-        let body = block_on(res.into_body().read_to_vec()).unwrap();
+        let body = block_on(body_to_vec(res.into_body())).unwrap();
         assert_eq!(&*body, &*b"bar");
     }
 
@@ -598,15 +598,15 @@ mod tests {
         router.apply_default_config(); // simulating App behavior
 
         let res = block_on(simulate_request(&router, "/", &http::Method::GET)).unwrap();
-        let body = block_on(res.into_body().read_to_vec()).unwrap();
+        let body = block_on(body_to_vec(res.into_body())).unwrap();
         assert_eq!(&*body, &*b"foo");
 
         let res = block_on(simulate_request(&router, "/bar", &http::Method::GET)).unwrap();
-        let body = block_on(res.into_body().read_to_vec()).unwrap();
+        let body = block_on(body_to_vec(res.into_body())).unwrap();
         assert_eq!(&*body, &*b"bar");
 
         let res = block_on(simulate_request(&router, "/bar/baz", &http::Method::GET)).unwrap();
-        let body = block_on(res.into_body().read_to_vec()).unwrap();
+        let body = block_on(body_to_vec(res.into_body())).unwrap();
         assert_eq!(&*body, &*b"baz");
     }
 
@@ -626,11 +626,11 @@ mod tests {
         router.apply_default_config(); // simulating App behavior
 
         let res = block_on(simulate_request(&router, "/", &http::Method::GET)).unwrap();
-        let body = block_on(res.into_body().read_to_vec()).unwrap();
+        let body = block_on(body_to_vec(res.into_body())).unwrap();
         assert_eq!(&*body, &*b"foo");
 
         let res = block_on(simulate_request(&router, "/bar", &http::Method::GET)).unwrap();
-        let body = block_on(res.into_body().read_to_vec()).unwrap();
+        let body = block_on(body_to_vec(res.into_body())).unwrap();
         assert_eq!(&*body, &*b"bar");
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -325,7 +325,7 @@ mod tests {
     use futures::{executor::block_on, future::FutureObj};
 
     use super::*;
-    use crate::{middleware::RequestContext, AppData, Response, body::body_to_vec};
+    use crate::{middleware::RequestContext, AppData, Response};
 
     fn passthrough_middleware<Data: Clone + Send>(
         ctx: RequestContext<Data>,
@@ -393,7 +393,7 @@ mod tests {
                     panic!("Routing of path `{}` failed", path);
                 };
             let body =
-                block_on(body_to_vec(res.into_body())).expect("Reading body should succeed");
+                block_on(res.into_body().into_vec()).expect("Reading body should succeed");
             assert_eq!(&*body, path.as_bytes());
         }
     }
@@ -444,7 +444,7 @@ mod tests {
                     panic!("Routing of path `{}` failed", path);
                 };
             let body =
-                block_on(body_to_vec(res.into_body())).expect("Reading body should succeed");
+                block_on(res.into_body().into_vec()).expect("Reading body should succeed");
             assert_eq!(&*body, path.as_bytes());
         }
     }
@@ -464,7 +464,7 @@ mod tests {
                 panic!("Routing of {} `{}` failed", method, path);
             };
             let body =
-                block_on(body_to_vec(res.into_body())).expect("Reading body should succeed");
+                block_on(res.into_body().into_vec()).expect("Reading body should succeed");
             assert_eq!(&*body, format!("{} {}", path, method).as_bytes());
         }
     }
@@ -570,11 +570,11 @@ mod tests {
         router.apply_default_config(); // simulating App behavior
 
         let res = block_on(simulate_request(&router, "/", &http::Method::GET)).unwrap();
-        let body = block_on(body_to_vec(res.into_body())).unwrap();
+        let body = block_on(res.into_body().into_vec()).unwrap();
         assert_eq!(&*body, &*b"foo");
 
         let res = block_on(simulate_request(&router, "/bar", &http::Method::GET)).unwrap();
-        let body = block_on(body_to_vec(res.into_body())).unwrap();
+        let body = block_on(res.into_body().into_vec()).unwrap();
         assert_eq!(&*body, &*b"bar");
     }
 
@@ -598,15 +598,15 @@ mod tests {
         router.apply_default_config(); // simulating App behavior
 
         let res = block_on(simulate_request(&router, "/", &http::Method::GET)).unwrap();
-        let body = block_on(body_to_vec(res.into_body())).unwrap();
+        let body = block_on(res.into_body().into_vec()).unwrap();
         assert_eq!(&*body, &*b"foo");
 
         let res = block_on(simulate_request(&router, "/bar", &http::Method::GET)).unwrap();
-        let body = block_on(body_to_vec(res.into_body())).unwrap();
+        let body = block_on(res.into_body().into_vec()).unwrap();
         assert_eq!(&*body, &*b"bar");
 
         let res = block_on(simulate_request(&router, "/bar/baz", &http::Method::GET)).unwrap();
-        let body = block_on(body_to_vec(res.into_body())).unwrap();
+        let body = block_on(res.into_body().into_vec()).unwrap();
         assert_eq!(&*body, &*b"baz");
     }
 
@@ -626,11 +626,11 @@ mod tests {
         router.apply_default_config(); // simulating App behavior
 
         let res = block_on(simulate_request(&router, "/", &http::Method::GET)).unwrap();
-        let body = block_on(body_to_vec(res.into_body())).unwrap();
+        let body = block_on(res.into_body().into_vec()).unwrap();
         assert_eq!(&*body, &*b"foo");
 
         let res = block_on(simulate_request(&router, "/bar", &http::Method::GET)).unwrap();
-        let body = block_on(body_to_vec(res.into_body())).unwrap();
+        let body = block_on(res.into_body().into_vec()).unwrap();
         assert_eq!(&*body, &*b"bar");
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,0 +1,86 @@
+use http_service::{Body, HttpService};
+use std::{
+    sync::Arc,
+    net::SocketAddr,
+};
+use futures::{
+    prelude::*,
+    compat::{Compat, Compat01As03, Future01CompatExt},
+    future::FutureObj
+};
+
+// Wrapper type to allow us to provide a blanket `MakeService` impl
+struct WrapHttpService<H> {
+    service: Arc<H>,
+}
+
+// Wrapper type to allow us to provide a blanket `Service` impl
+struct WrapConnection<H: HttpService> {
+    service: Arc<H>,
+    connection: H::Connection,
+}
+
+impl<H, Ctx> hyper::service::MakeService<Ctx> for WrapHttpService<H> where H: HttpService {
+    type ReqBody = hyper::Body;
+    type ResBody = hyper::Body;
+    type Error = std::io::Error;
+    type Service = WrapConnection<H>;
+    type Future = Compat<FutureObj<'static, Result<Self::Service, Self::Error>>>;
+    type MakeError = std::io::Error;
+
+    fn make_service(&mut self, _ctx: Ctx) -> Self::Future {
+        let service = self.service.clone();
+        let error = std::io::Error::from(std::io::ErrorKind::Other);
+        FutureObj::new(Box::new(
+            async move {
+                let connection = await!(service.connect().into_future()).map_err(|_| error)?;
+                Ok(WrapConnection { service, connection })
+            }
+        )).compat()
+
+    }
+}
+
+impl<H> hyper::service::Service for WrapConnection<H> where H: HttpService {
+    type ReqBody = hyper::Body;
+    type ResBody = hyper::Body;
+    type Error = std::io::Error;
+    type Future = Compat<FutureObj<'static, Result<http::Response<hyper::Body>, Self::Error>>>;
+
+    fn call(&mut self, req: http::Request<hyper::Body>) -> Self::Future {
+        let error = std::io::Error::from(std::io::ErrorKind::Other);
+        let req = req.map(|hyper_body| {
+            let stream = Compat01As03::new(hyper_body).map(|c| match c {
+                Ok(chunk) => Ok(chunk.into_bytes()),
+                Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
+            });
+            Body::from_stream(stream)
+        });
+        let fut = self.service.respond(&mut self.connection, req);
+
+        FutureObj::new(Box::new(
+            async move {
+                let res: http::Response<_> = await!(fut.into_future()).map_err(|_| error)?;
+                Ok(res.map(|body| {
+                    hyper::Body::wrap_stream(body.compat())
+                }))
+            }
+        )).compat()
+    }
+}
+
+// Use hyper to serve the given HttpService at the given address
+pub(crate) fn serve<S: HttpService>(s: S, addr: SocketAddr) {
+    let service = WrapHttpService {
+        service: Arc::new(s),
+    };
+    let server = hyper::Server::bind(&addr)
+        .serve(service)
+        .compat()
+        .map(|_| {
+            let res: Result<(), ()> = Ok(());
+            res
+        })
+        .compat();
+    hyper::rt::run(server);
+}


### PR DESCRIPTION
## Description

This PR refactors Tide to internally use the new [http-service crate](https://github.com/rust-net-web/http-service). That crate provides an `HttpService` trait, meant to provide a Rack-like interface between low-level http servers (like hyper) and frameworks or applications that sit on top of them.

The refactoring isolates all hyper-specific shim code to a new module, `serve`, which presents an `HttpService`-based interface to the rest of the crate. Eventually this shim code should be moved into an external crate.

## Motivation and Context

The ultimate goals here are:

- To move the shim code to work with hyper into a separate crate
- To support a standardized layering such that the base web server can easily be switched out (in Tide and other web frameworks)

## How Has This Been Tested?

As a pure refactoring, no new tests are added.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
